### PR TITLE
Fix: Prevent bot crash on Gemini API errors

### DIFF
--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -34,7 +34,7 @@ func generateResponse(prompt string) string {
 		Backend: genai.BackendGeminiAPI,
 	})
 	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
+		log.Errorf("failed to create client: %v", err)
 		return ""
 	}
 
@@ -45,7 +45,7 @@ func generateResponse(prompt string) string {
 
 	resp, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash", content, nil)
 	if err != nil {
-		log.Fatalf("failed to generate content: %v", err)
+		log.Errorf("failed to generate content: %v", err)
 		return ""
 	}
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -316,6 +316,23 @@ func (manager *Manager) handlePing() Response {
 
 func (manager *Manager) onHelp(interaction *Interaction) {
 	response := gemini.GenerateHelpfulResponse("(user issued the help command, return a nicely formatted help menu)")
+	if response == "" {
+		response = `**Music Control:**
+/play (or /queue) - Queue a song. Takes a search query, YouTube URL, or Spotify track URL
+/skip - Skip the current song and play the next in queue
+/pause (or /stop) - Pause the current song
+/resume - Resume playback
+/volume - Set playback volume (0-100)
+
+**Queue Management:**
+/view - View the current queue
+/remove - Remove a song from the queue by index number
+/reset - Clear everything and reset the player
+
+**Other:**
+/help - Show this help menu
+/ping - Check if the bot is alive`
+	}
 	manager.SendRequest(interaction, response, false)
 }
 


### PR DESCRIPTION
## Summary
- Changed `log.Fatalf` to `log.Errorf` in gemini.go to prevent crashes when Gemini API returns errors (quota exceeded, network failures, etc.)
- Added fallback help menu in handlers.go for when Gemini is unavailable

## Test plan
- Run `/help` when Gemini is disabled or quota exhausted - should show the fallback help menu instead of crashing
- Trigger any command that calls Gemini with an invalid API key - bot should log error and continue running

🤖 Generated with Claude Code