### PR TITLE
Add .zed/settings.json for Go editor configuration

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,27 @@
+{
+  "tab_size": 4,
+  "formatter": "language_server",
+  "format_on_save": "on",
+  "languages": {
+    "Go": {
+      "tab_size": 4,
+      "hard_tabs": true,
+      "format_on_save": "on",
+      "formatter": "language_server"
+    }
+  },
+  "lsp": {
+    "gopls": {
+      "initialization_options": {
+        "hints": {
+          "assignVariableTypes": true,
+          "compositeLiteralFields": true,
+          "constantValues": true,
+          "functionTypeParameters": true,
+          "parameterNames": true,
+          "rangeVariableTypes": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds Zed editor configuration file with Go-appropriate settings.

Configures hard tabs (Go convention), tab size 4, format-on-save with gopls, and inlay hints for types. This ensures a consistent development experience for team members using Zed.