### PR TITLE
feat: add shuffle command

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -108,5 +108,10 @@
     "name": "purge",
     "type": 1,
     "description": "Purges the queue"
+  },
+  {
+    "name": "shuffle",
+    "type": 1,
+    "description": "Shuffles the current queue"
   }
 ]

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"strconv"
 	"strings"
 	"sync"
@@ -868,4 +869,20 @@ func (p *GuildPlayer) IsEmpty() bool {
 	p.Queue.Mutex.Lock()
 	defer p.Queue.Mutex.Unlock()
 	return len(p.Queue.Items) == 0
+}
+
+func (p *GuildPlayer) Shuffle() int {
+	p.Queue.Mutex.Lock()
+	defer p.Queue.Mutex.Unlock()
+
+	if len(p.Queue.Items) <= 1 {
+		return len(p.Queue.Items)
+	}
+
+	// Shuffle only affects queued songs; currently playing song (if any) is not in queue
+	rand.Shuffle(len(p.Queue.Items), func(i, j int) {
+		p.Queue.Items[i], p.Queue.Items[j] = p.Queue.Items[j], p.Queue.Items[i]
+	})
+
+	return len(p.Queue.Items)
 }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -817,6 +817,37 @@ func (manager *Manager) handleResume(interaction *Interaction) Response {
 	}
 }
 
+func (manager *Manager) handleShuffle(interaction *Interaction) Response {
+	player := manager.Controller.GetPlayer(interaction.GuildID)
+
+	count := player.Shuffle()
+
+	if count == 0 {
+		return Response{
+			Type: 4,
+			Data: ResponseData{
+				Content: "the queue is empty, nothing to shuffle",
+			},
+		}
+	}
+
+	if count == 1 {
+		return Response{
+			Type: 4,
+			Data: ResponseData{
+				Content: "only one song in the queue, nothing to shuffle",
+			},
+		}
+	}
+
+	return Response{
+		Type: 4,
+		Data: ResponseData{
+			Content: "@" + interaction.Member.User.Username + " shuffled the queue (" + strconv.Itoa(count) + " songs)",
+		},
+	}
+}
+
 func (manager *Manager) HandleInteraction(interaction *Interaction) (response Response) {
 	defer func() {
 		if err := recover(); err != nil {
@@ -875,6 +906,8 @@ func (manager *Manager) HandleInteraction(interaction *Interaction) (response Re
 		return manager.handleResume(interaction)
 	case "reset":
 		return manager.handleReset(interaction)
+	case "shuffle":
+		return manager.handleShuffle(interaction)
 	// case "purge":
 	// 	return manager.handlePurge(interaction)
 	default:


### PR DESCRIPTION
## Summary
Added a new `/shuffle` command that randomizes the order of songs in the queue.

## Changes
- Registers `/shuffle` command in Discord
- Implements queue shuffling with thread-safe mutex protection
- Handles edge cases: empty queue and single song

## Testing
- Empty queue returns "nothing to shuffle"
- Single song returns appropriate message
- Multiple songs shows shuffle count in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)