### PR TITLE
Add Spotify album support with refactored collection handler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,10 @@
   - Duplicates already in queue are skipped
   - Partial failures handled gracefully (queue what's found, report what's missing)
   - Sentry spans: `spotify.get_playlist_tracks`, `youtube.parallel_search`
+- **Album URLs**: Fetch first 15 tracks → parallel YouTube search → queue all found
+  - Same parallel processing pattern as playlists
+  - Hardcoded limit of 15 tracks (sufficient for most albums)
+  - Sentry spans: `spotify.get_album_tracks`, `youtube.parallel_search`
 - Artist URLs return "coming soon" message
 - Optional feature, disabled by default (`SPOTIFY_ENABLED=false`)
 - Requires Spotify API credentials (`SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`)


### PR DESCRIPTION
Adds full support for Spotify album URLs to the /queue command. Fetches up to 15 tracks from albums and queues them via parallel YouTube searches, following the same pattern as playlists. Refactors common logic into a shared handleSpotifyCollection() helper to eliminate ~180 lines of code duplication. Also backports AI prompt truncation optimization to reduce token costs for large collections. Updates help text to document album URL support.