### PR TITLE
fix: Use auto-refreshing OAuth2 client for Spotify token refresh

### DIFF
--- a/spotify/client.go
+++ b/spotify/client.go
@@ -52,13 +52,10 @@ func NewSpotifyClient() error {
 		ClientSecret: os.Getenv("SPOTIFY_CLIENT_SECRET"),
 		TokenURL:     spotifyauth.TokenURL,
 	}
-	token, err := config.Token(ctx)
-	if err != nil {
-		sentry.CaptureException(err)
-		return err
-	}
 
-	httpClient := spotifyauth.New().Client(ctx, token)
+	// Use config.Client() which returns an HTTP client that automatically
+	// refreshes tokens when they expire (Spotify tokens last 1 hour)
+	httpClient := config.Client(ctx)
 	client := spotifyclient.New(httpClient)
 	Spotify = client
 	return nil


### PR DESCRIPTION
Fixes DISCORD-MUSIC-BOT-K. The previous implementation fetched a static token once at startup, which expires after 1 hour. This change uses `config.Client()` instead, which returns an HTTP client that automatically refreshes tokens when they expire, ensuring the Spotify API remains accessible indefinitely.

**Changes:**
- Simplified `NewSpotifyClient()` to use `config.Client(ctx)` for automatic token refresh
- Removed manual token fetch and error handling (lazy validation)
- Added comment explaining the 1-hour token expiration and auto-refresh behavior