### PR TITLE
perf: increase Docker memory limits to 1.5GB

### DIFF
--- a/docker-restart.sh
+++ b/docker-restart.sh
@@ -27,9 +27,9 @@ fi
 
 docker run -d --name discord-music-bot \
   --restart always \
-  --memory="1g" \
-  --memory-reservation="512m" \
-  --memory-swap="2g" \
+  --memory="1.5g" \
+  --memory-reservation="768m" \
+  --memory-swap="2.5g" \
   --cpus="2" \
   --cpu-shares="2048" \
   -e DISCORD_APP_ID=$DISCORD_APP_ID \


### PR DESCRIPTION
Boost Docker memory allocation from 1GB to 1.5GB hard limit with proportional increases to soft reservation (768MB) and swap (2.5GB). This provides 50% more buffer for audio buffering and FFmpeg operations while remaining conservative on the 8GB system (only ~20% utilization). The change prevents out-of-memory issues during long playlists without impacting other applications.