### PR TITLE
Add YouTube playlist support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,15 @@
 - Player state (`paused`, `stopping`) uses atomics, not mutexes
 - Mutex in Play() held for entire duration - avoid adding more mutex contention
 
+#### YouTube Playlist Integration
+- **Playlist URLs**: Fetch videos from YouTube API → deduplicate against queue → queue all found
+  - Default limit: 15 videos (configurable via `YOUTUBE_PLAYLIST_LIMIT`, max 50)
+  - Handles `youtube.com/playlist?list=...` and `youtube.com/watch?v=...&list=...` URLs
+  - Duplicates already in queue are skipped
+  - Private/deleted playlists handled gracefully with user-friendly errors
+  - Sentry span: `youtube.get_playlist_videos`
+- Simpler than Spotify since we already have video IDs (no YouTube search step needed)
+
 #### Spotify Integration
 - **Track URLs**: Spotify URL → parse track ID → fetch metadata → YouTube search → queue
 - **Playlist URLs**: Fetch first N tracks (configurable) → parallel YouTube search → queue all found
@@ -165,6 +174,7 @@ Key vars in `.env`:
 - `DISCORD_BOT_TOKEN` - Required
 - `DISCORD_APP_ID` - Required
 - `YOUTUBE_API_KEY` - Required for searches
+- `YOUTUBE_PLAYLIST_LIMIT` - Max videos to fetch from YouTube playlists (default: 15, max: 50)
 - `SPOTIFY_CLIENT_ID` - Spotify API client ID (optional)
 - `SPOTIFY_CLIENT_SECRET` - Spotify API client secret (optional)
 - `SPOTIFY_ENABLED` - Enable Spotify URL parsing (default: false)

--- a/README.md
+++ b/README.md
@@ -65,10 +65,14 @@ A simple bot implementation for playing audio in Discord voice channels using [y
    NGROK_AUTHTOKEN=your_ngrok_token
    NGROK_DOMAIN=your_reserved_domain
 
+   # Optional - YouTube playlist limit
+   YOUTUBE_PLAYLIST_LIMIT=15
+
    # Optional - Spotify integration
    SPOTIFY_ENABLED=false
    SPOTIFY_CLIENT_ID=your_spotify_client_id
    SPOTIFY_CLIENT_SECRET=your_spotify_client_secret
+   SPOTIFY_PLAYLIST_LIMIT=10
 
    # Optional - Gemini AI
    GEMINI_ENABLED=false
@@ -145,12 +149,20 @@ A simple bot implementation for playing audio in Discord voice channels using [y
 
 ## Optional Features
 
+### YouTube Playlist Support
+
+Queue entire YouTube playlists with a single command. Just paste a YouTube playlist URL.
+
+- Default limit: 15 videos per playlist
+- Set `YOUTUBE_PLAYLIST_LIMIT` to change (max 50)
+
 ### Spotify Integration
 
-Parses Spotify track URLs and searches YouTube for the corresponding song. Only individual track URLs are supported (playlists coming soon).
+Parses Spotify track, playlist, and album URLs and searches YouTube for the corresponding songs.
 
 - Get credentials from [Spotify Developer Dashboard](https://developer.spotify.com/dashboard)
 - Set `SPOTIFY_ENABLED=true` and configure `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET`
+- Set `SPOTIFY_PLAYLIST_LIMIT` to change the default playlist limit (default 10, max 50)
 
 ### Gemini AI
 

--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,8 @@ type NGrokConfig struct {
 }
 
 type YoutubeConfig struct {
-	APIKey string
+	APIKey        string
+	PlaylistLimit int
 }
 
 type GeminiConfig struct {
@@ -74,7 +75,8 @@ func NewConfig() {
 			IdleTimeoutMinutes:  getIdleTimeout(),
 		},
 		Youtube: YoutubeConfig{
-			APIKey: os.Getenv("YOUTUBE_API_KEY"),
+			APIKey:        os.Getenv("YOUTUBE_API_KEY"),
+			PlaylistLimit: getYouTubePlaylistLimit(),
 		},
 		Gemini: GeminiConfig{
 			Enabled: os.Getenv("GEMINI_ENABLED") == "true",
@@ -114,6 +116,21 @@ func getPlaylistLimit() int {
 	}
 	if limit > 50 {
 		return 50 // Cap at 50 for API and performance reasons
+	}
+	return limit
+}
+
+func getYouTubePlaylistLimit() int {
+	limitStr := os.Getenv("YOUTUBE_PLAYLIST_LIMIT")
+	if limitStr == "" {
+		return 15
+	}
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit <= 0 {
+		return 15
+	}
+	if limit > 50 {
+		return 50 // Cap at 50 (YouTube API max per page)
 	}
 	return limit
 }

--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -121,7 +121,7 @@ Keep it concise - a few sentences max. You can curse if it feels natural.
 Here are the available commands:
 
 **Music Control:**
-/play (or /queue) - Queue a song. Takes a search query, YouTube URL, or Spotify track URL
+/play (or /queue) - Queue a song. Takes a search query, YouTube URL/playlist, or Spotify URL. Note: YouTube links with ?list= will queue the whole playlist
 /skip - Skip the current song and play the next in queue
 /pause (or /stop) - Pause the current song
 /resume - Resume playback


### PR DESCRIPTION
## Summary
Adds YouTube playlist support to the /queue command, allowing users to queue entire YouTube playlists with a single command. Implementation mirrors the existing Spotify playlist/album pattern for consistency.

## Changes
- YouTube playlist URL detection and video fetching via YouTube API v3
- Configurable playlist limit (default 15, max 50) via `YOUTUBE_PLAYLIST_LIMIT` env var
- Duplicate detection and graceful error handling for private/deleted playlists
- Documentation updates (README, help text, CLAUDE.md)

## Testing
Test with public YouTube playlists of various sizes:
- `https://www.youtube.com/playlist?list=PLxxxxxxx`
- Video URLs with playlist context `https://www.youtube.com/watch?v=VIDEO&list=PLxxxxxxx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)