### PR TITLE
fix: Isolated Sentry tracing and breadcrumb scoping per command

### DIFF
--- a/audio/player.go
+++ b/audio/player.go
@@ -266,7 +266,8 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 	}
 }
 
-func (p *Player) Pause() {
+func (p *Player) Pause(ctx context.Context) {
+	_ = ctx // ctx available for future Sentry tracing if needed
 	p.logger.Info("Pausing playback - starting fade-out")
 	if p.fadeOutRemaining == 0 {
 		p.fadeOutRemaining = 5 // 5 frames = 100ms fade-out
@@ -277,7 +278,8 @@ func (p *Player) Pause() {
 	}
 }
 
-func (p *Player) Resume() {
+func (p *Player) Resume(ctx context.Context) {
+	_ = ctx // ctx available for future Sentry tracing if needed
 	p.logger.Info("Resuming playback")
 	p.fadeOutRemaining = 0 // Cancel any ongoing fade-out
 	p.paused.Store(false)

--- a/discord/messages.go
+++ b/discord/messages.go
@@ -2,6 +2,7 @@ package discord
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -24,7 +25,8 @@ func buildRequest(request *FollowUpRequest) map[string]interface{} {
 	var content string = request.Content
 
 	if request.GenerateContent {
-		content = gemini.GenerateResponse(request.Content)
+		// Use background context since this is called from async goroutines
+		content = gemini.GenerateResponse(context.Background(), request.Content)
 		if content == "" {
 			content = request.Content
 		}

--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -23,9 +23,7 @@ func printResponse(resp *genai.GenerateContentResponse) {
 	fmt.Println("---")
 }
 
-func generateResponse(prompt string) string {
-	ctx := context.Background()
-
+func generateResponse(ctx context.Context, prompt string) string {
 	if !config.Config.Gemini.Enabled {
 		return ""
 	}
@@ -96,17 +94,17 @@ func buildPrompt(customPrompt string) string {
 	return strings.Join(instructions, "\n")
 }
 
-func GenerateResponse(prompt string) string {
+func GenerateResponse(ctx context.Context, prompt string) string {
 	if !config.Config.Gemini.Enabled {
 		return ""
 	}
 
 	instructions := buildPrompt(prompt)
 
-	return generateResponse(instructions)
+	return generateResponse(ctx, instructions)
 }
 
-func GenerateHelpfulResponse(prompt string) string {
+func GenerateHelpfulResponse(ctx context.Context, prompt string) string {
 	if !config.Config.Gemini.Enabled {
 		return ""
 	}
@@ -137,5 +135,5 @@ Here are the available commands:
 /ping - Check if the bot is alive
 Prompt: ` + prompt
 
-	return generateResponse(instructions)
+	return generateResponse(ctx, instructions)
 }

--- a/main.go
+++ b/main.go
@@ -110,9 +110,9 @@ func run(ctx context.Context) error {
 
 	router.GET("/youtube/search", func(c *gin.Context) {
 		query := c.Query("query")
-		videos := youtube.Query(query)
+		videos := youtube.Query(c.Request.Context(), query)
 
-		stream, err := youtube.GetVideoStream(videos[0])
+		stream, err := youtube.GetVideoStream(c.Request.Context(), videos[0])
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get video stream"})
 			return
@@ -131,7 +131,7 @@ func run(ctx context.Context) error {
 				return
 			}
 			prompt := string(bodyBytes)
-			response := gemini.GenerateResponse(prompt)
+			response := gemini.GenerateResponse(c.Request.Context(), prompt)
 			c.JSON(http.StatusOK, gin.H{
 				"response": response,
 			})
@@ -144,7 +144,7 @@ func run(ctx context.Context) error {
 				return
 			}
 			prompt := string(bodyBytes)
-			response := gemini.GenerateHelpfulResponse(prompt)
+			response := gemini.GenerateHelpfulResponse(c.Request.Context(), prompt)
 			c.JSON(http.StatusOK, gin.H{
 				"response": response,
 			})

--- a/sentryhelper/helpers.go
+++ b/sentryhelper/helpers.go
@@ -1,0 +1,116 @@
+// Package sentryhelper provides utilities for Sentry transaction and scope management.
+// It ensures proper isolation of breadcrumbs and context per Discord command.
+package sentryhelper
+
+import (
+	"context"
+	"fmt"
+
+	sentry "github.com/getsentry/sentry-go"
+)
+
+// contextKey is used to store the cloned hub in context
+type contextKey string
+
+const hubContextKey contextKey = "sentry_hub"
+
+// StartCommandTransaction creates a new transaction with a cloned hub for a Discord command.
+// The cloned hub ensures breadcrumbs and scope are isolated to this command only.
+// Returns the context with the transaction and hub, plus the transaction span.
+func StartCommandTransaction(ctx context.Context, commandName string, guildID string, userID string) (context.Context, *sentry.Span) {
+	// Clone the hub to isolate scope (breadcrumbs, tags, user context)
+	hub := sentry.CurrentHub().Clone()
+
+	// Put the cloned hub into the context
+	ctx = context.WithValue(ctx, hubContextKey, hub)
+
+	// Start the transaction
+	transactionName := fmt.Sprintf("discord.command.%s", commandName)
+	transaction := sentry.StartTransaction(ctx, transactionName,
+		sentry.WithOpName("discord.command"),
+		sentry.WithTransactionSource(sentry.SourceRoute),
+	)
+
+	// Set initial tags on the transaction
+	transaction.SetTag("command", commandName)
+	transaction.SetTag("guild_id", guildID)
+	transaction.SetTag("user_id", userID)
+
+	// Bind the transaction to the cloned hub's scope
+	hub.Scope().SetSpan(transaction)
+
+	return transaction.Context(), transaction
+}
+
+// HubFromContext retrieves the cloned hub from context.
+// Falls back to CurrentHub if no cloned hub is found (for backward compatibility).
+func HubFromContext(ctx context.Context) *sentry.Hub {
+	if ctx == nil {
+		return sentry.CurrentHub()
+	}
+	if hub, ok := ctx.Value(hubContextKey).(*sentry.Hub); ok && hub != nil {
+		return hub
+	}
+	return sentry.CurrentHub()
+}
+
+// AddBreadcrumb adds a breadcrumb to the hub in context (isolated per-command).
+func AddBreadcrumb(ctx context.Context, breadcrumb *sentry.Breadcrumb) {
+	hub := HubFromContext(ctx)
+	hub.AddBreadcrumb(breadcrumb, nil)
+}
+
+// CaptureException captures an exception on the hub in context.
+func CaptureException(ctx context.Context, err error) *sentry.EventID {
+	hub := HubFromContext(ctx)
+	return hub.CaptureException(err)
+}
+
+// CaptureMessage captures a message on the hub in context.
+// Use this for warnings or informational events that aren't errors.
+func CaptureMessage(ctx context.Context, message string) *sentry.EventID {
+	hub := HubFromContext(ctx)
+	return hub.CaptureMessage(message)
+}
+
+// ConfigureScope configures the scope on the hub in context.
+func ConfigureScope(ctx context.Context, f func(*sentry.Scope)) {
+	hub := HubFromContext(ctx)
+	hub.ConfigureScope(f)
+}
+
+// StartSpan starts a child span attached to the transaction in context.
+// If no transaction exists in context, creates an orphaned span (for backward compatibility).
+func StartSpan(ctx context.Context, operation string) *sentry.Span {
+	return sentry.StartSpan(ctx, operation)
+}
+
+// DetachFromTransaction creates a new context that preserves the cloned hub
+// but removes the transaction association. Use this for queue items that may
+// be processed long after the original command transaction has finished.
+// Breadcrumbs and scope will still be isolated to the command's hub.
+func DetachFromTransaction(ctx context.Context) context.Context {
+	hub := HubFromContext(ctx)
+	// Create a fresh context with only the hub, no transaction
+	return context.WithValue(context.Background(), hubContextKey, hub)
+}
+
+// StartLinkedTransaction creates a new transaction that references an original
+// command via tags. Use this for long-running operations (like audio loading/playback)
+// that happen after the original command transaction has finished.
+func StartLinkedTransaction(ctx context.Context, name string, operation string, commandName string, guildID string) (context.Context, *sentry.Span) {
+	hub := HubFromContext(ctx)
+
+	transaction := sentry.StartTransaction(ctx, name,
+		sentry.WithOpName(operation),
+		sentry.WithTransactionSource(sentry.SourceTask),
+	)
+
+	transaction.SetTag("original_command", commandName)
+	transaction.SetTag("guild_id", guildID)
+
+	// Bind the transaction to the hub's scope
+	hub.Scope().SetSpan(transaction)
+
+	return transaction.Context(), transaction
+}

--- a/spotify/client.go
+++ b/spotify/client.go
@@ -61,9 +61,7 @@ func NewSpotifyClient() error {
 	return nil
 }
 
-func Search(query string) (spotifyclient.SearchResult, error) {
-	ctx := context.Background()
-
+func Search(ctx context.Context, query string) (spotifyclient.SearchResult, error) {
 	// Start span for Spotify search
 	span := sentry.StartSpan(ctx, "spotify.search")
 	span.Description = "Search Spotify API"
@@ -81,9 +79,8 @@ func Search(query string) (spotifyclient.SearchResult, error) {
 	return *results, nil
 }
 
-func GetTrack(trackID string) (*TrackInfo, error) {
+func GetTrack(ctx context.Context, trackID string) (*TrackInfo, error) {
 	log.Tracef("Fetching track from Spotify API: %s", trackID)
-	ctx := context.Background()
 
 	// Start span for Spotify API call
 	span := sentry.StartSpan(ctx, "spotify.get_track")
@@ -112,9 +109,7 @@ func GetTrack(trackID string) (*TrackInfo, error) {
 	}, nil
 }
 
-func GetArtistTopSongs(artistID string) ([]string, error) {
-	ctx := context.Background()
-
+func GetArtistTopSongs(ctx context.Context, artistID string) ([]string, error) {
 	// Start span for Spotify artist top tracks
 	span := sentry.StartSpan(ctx, "spotify.get_artist_top_songs")
 	span.Description = "Get artist top songs from Spotify API"
@@ -137,9 +132,8 @@ func GetArtistTopSongs(artistID string) ([]string, error) {
 	return names, nil
 }
 
-func GetPlaylistTracks(playlistID string, limit int) (*PlaylistResult, error) {
+func GetPlaylistTracks(ctx context.Context, playlistID string, limit int) (*PlaylistResult, error) {
 	log.Tracef("Fetching playlist tracks from Spotify API: %s (limit: %d)", playlistID, limit)
-	ctx := context.Background()
 
 	span := sentry.StartSpan(ctx, "spotify.get_playlist_tracks")
 	span.Description = "Get playlist tracks from Spotify API"
@@ -224,9 +218,8 @@ func GetPlaylistTracks(playlistID string, limit int) (*PlaylistResult, error) {
 	}, nil
 }
 
-func GetAlbumTracks(albumID string) (*AlbumResult, error) {
+func GetAlbumTracks(ctx context.Context, albumID string) (*AlbumResult, error) {
 	log.Tracef("Fetching album tracks from Spotify API: %s", albumID)
-	ctx := context.Background()
 
 	span := sentry.StartSpan(ctx, "spotify.get_album_tracks")
 	span.Description = "Get album tracks from Spotify API"

--- a/youtube/client.go
+++ b/youtube/client.go
@@ -85,10 +85,10 @@ func ParseYouTubeURL(_url string) YouTubeURLResult {
 	}
 }
 
-func GetVideoByID(videoID string) (VideoResponse, error) {
+func GetVideoByID(ctx context.Context, videoID string) (VideoResponse, error) {
 	api_key := config.Config.Youtube.APIKey
 
-	service, err := ytapi.NewService(context.Background(), option.WithAPIKey(api_key))
+	service, err := ytapi.NewService(ctx, option.WithAPIKey(api_key))
 	if err != nil {
 		log.Errorf("error creating YouTube client: %v", err)
 		return VideoResponse{}, fmt.Errorf("error creating YouTube client: %v", err)
@@ -113,18 +113,18 @@ func GetVideoByID(videoID string) (VideoResponse, error) {
 }
 
 // GetPlaylistVideos fetches videos from a YouTube playlist
-func GetPlaylistVideos(playlistID string, limit int) (*PlaylistResult, error) {
+func GetPlaylistVideos(ctx context.Context, playlistID string, limit int) (*PlaylistResult, error) {
 	logger := log.WithFields(log.Fields{"module": "youtube", "function": "GetPlaylistVideos", "playlist_id": playlistID})
 
 	// Start Sentry span
-	span := sentry.StartSpan(context.Background(), "youtube.get_playlist_videos")
+	span := sentry.StartSpan(ctx, "youtube.get_playlist_videos")
 	span.Description = "Fetch YouTube playlist videos"
 	span.SetTag("playlist_id", playlistID)
 	span.SetTag("limit", strconv.Itoa(limit))
 	defer span.Finish()
 
 	apiKey := config.Config.Youtube.APIKey
-	service, err := ytapi.NewService(context.Background(), option.WithAPIKey(apiKey))
+	service, err := ytapi.NewService(ctx, option.WithAPIKey(apiKey))
 	if err != nil {
 		logger.Errorf("error creating YouTube client: %v", err)
 		sentry.CaptureException(err)
@@ -209,18 +209,18 @@ func GetPlaylistVideos(playlistID string, limit int) (*PlaylistResult, error) {
 	}, nil
 }
 
-func Query(query string) []VideoResponse {
+func Query(ctx context.Context, query string) []VideoResponse {
 	logger := log.WithFields(log.Fields{"module": "youtube", "function": "Query"})
 
 	// Start span for YouTube API search
-	span := sentry.StartSpan(context.Background(), "youtube.search")
+	span := sentry.StartSpan(ctx, "youtube.search")
 	span.Description = "Search YouTube API"
 	span.SetTag("query", query)
 	defer span.Finish()
 
 	api_key := config.Config.Youtube.APIKey
 
-	service, err := ytapi.NewService(context.Background(), option.WithAPIKey(api_key))
+	service, err := ytapi.NewService(ctx, option.WithAPIKey(api_key))
 	if err != nil {
 		logger.Errorf("error creating YouTube client: %v", err)
 		sentry.CaptureException(err)
@@ -285,11 +285,11 @@ func Query(query string) []VideoResponse {
 	return videos
 }
 
-func GetVideoStream(videoResponse VideoResponse) (*YoutubeStream, error) {
+func GetVideoStream(ctx context.Context, videoResponse VideoResponse) (*YoutubeStream, error) {
 	logger := log.WithFields(log.Fields{"module": "youtube", "video_id": videoResponse.VideoID, "function": "GetVideoStream"})
 
 	// Start span for yt-dlp execution
-	span := sentry.StartSpan(context.Background(), "youtube.get_stream")
+	span := sentry.StartSpan(ctx, "youtube.get_stream")
 	span.Description = "Get video stream URL via yt-dlp"
 	span.SetTag("video_id", videoResponse.VideoID)
 	defer span.Finish()


### PR DESCRIPTION
## Summary
Fixes empty traces and breadcrumb accumulation by creating per-command transactions with cloned hubs for scope isolation.

## Changes
- Create `sentryhelper` package for hub cloning and transaction management
- Thread context through all handlers and controller methods
- Add panic recovery to command goroutines to capture panics in Sentry
- Detach queue items from original transaction to prevent orphaned spans
- Replace global `sentry.AddBreadcrumb` calls with context-scoped alternatives

## Fixes
- **Empty traces**: Each Discord command now creates a root transaction that properly links child spans
- **Breadcrumb accumulation**: Each command gets its own cloned hub scope, isolating breadcrumbs per-command
- **Panic handling**: Panics in goroutines are now captured in Sentry with proper error context

🤖 Generated with [Claude Code](https://claude.com/claude-code)