### PR TITLE
feat: Radio mode - auto-queue similar songs when queue empties

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -113,5 +113,10 @@
     "name": "shuffle",
     "type": 1,
     "description": "Shuffles the current queue"
+  },
+  {
+    "name": "radio",
+    "type": 1,
+    "description": "Toggle radio mode - automatically queues similar songs when the queue is empty"
   }
 ]

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -1154,6 +1154,27 @@ func (manager *Manager) handleShuffle(interaction *Interaction) Response {
 	}
 }
 
+func (manager *Manager) handleRadio(interaction *Interaction) Response {
+	player := manager.Controller.GetPlayer(interaction.GuildID)
+	player.LastTextChannelID = interaction.ChannelID
+
+	enabled := player.ToggleRadio()
+
+	var msg string
+	if enabled {
+		msg = "📻 Radio mode **enabled** — I'll automatically queue similar songs when the queue runs out"
+	} else {
+		msg = "📻 Radio mode **disabled**"
+	}
+
+	return Response{
+		Type: 4,
+		Data: ResponseData{
+			Content: msg,
+		},
+	}
+}
+
 func (manager *Manager) HandleInteraction(interaction *Interaction) (response Response) {
 	// Create transaction with cloned hub for scope isolation (breadcrumbs per-command)
 	ctx, transaction := sentryhelper.StartCommandTransaction(
@@ -1232,6 +1253,8 @@ func (manager *Manager) HandleInteraction(interaction *Interaction) (response Re
 		return manager.handleReset(ctx, transaction, interaction)
 	case "shuffle":
 		return manager.handleShuffle(interaction)
+	case "radio":
+		return manager.handleRadio(interaction)
 	// case "purge":
 	// 	return manager.handlePurge(interaction)
 	default:


### PR DESCRIPTION
## Radio Mode

Adds a `/radio` slash command that toggles radio mode. When enabled, the bot automatically searches for and queues similar songs when the queue runs out.

### How it works
- Maintains a ring buffer of the last 20 played songs (`SongHistory`)
- When the queue empties and radio is on, picks a random recent song's artist
- Searches YouTube for that artist and queues the first result not already in history
- Falls back to a different artist from history if all results are duplicates
- Announces the auto-queued song in the text channel

### Changes
- **`controller/controller.go`**: `SongHistory` ring buffer, `ToggleRadio()`, `IsRadioEnabled()`, `ExtractArtist()` title parser, `queueRadioSong()` auto-queue logic
- **`handlers/handlers.go`**: `handleRadio()` slash command handler
- **`commands.json`**: New `/radio` command registration

### Notes
- Rebased on main to include the OpusSend panic fix (#31 equivalent)
- Radio triggering happens in `listenForPlaybackEvents` after `PlaybackCompleted`
- Duplicate detection uses both song history and current queue