### PR TITLE
fix: prevent infinite loop when stop/fade-out hits EOF

### DIFF
--- a/audio/player.go
+++ b/audio/player.go
@@ -112,6 +112,11 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 				if err != nil {
 					if err == io.EOF || err == io.ErrUnexpectedEOF {
 						p.fadeOutRemaining = 0
+						if p.stopping.Load() {
+							p.logger.Debug("EOF during fade-out, stopping playback")
+							span.Status = sentry.SpanStatusCanceled
+							return nil
+						}
 						continue
 					}
 					p.logger.Warnf("Error reading during fade-out: %v", err)


### PR DESCRIPTION
Fixes a bug where the player gets stuck in an infinite tight loop spamming "Stop requested, starting fade-out" and eating 100%+ CPU.

**Root cause:** When `Stop()` triggers fade-out but ffmpeg's stream has already hit EOF, the fade-out code resets `fadeOutRemaining = 0` and `continue`s. This skips the fade-out completion return, falls through to the stop check which re-arms `fadeOutRemaining = 5`, and loops back into the EOF path. No sleep on that path = 100% CPU.

**Fix:** When EOF occurs during fade-out while stopping, return immediately instead of continuing the loop.