### PR TITLE
feat: add /history and /leaderboard commands

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -118,5 +118,35 @@
     "name": "radio",
     "type": 1,
     "description": "Toggle radio mode - automatically queues similar songs when the queue is empty"
+  },
+  {
+    "name": "history",
+    "type": 1,
+    "description": "Shows recently played songs in this server",
+    "options": [
+      {
+        "name": "limit",
+        "type": 4,
+        "description": "Number of songs to show (default 10, max 25)",
+        "required": false,
+        "min_value": 1,
+        "max_value": 25
+      }
+    ]
+  },
+  {
+    "name": "leaderboard",
+    "type": 1,
+    "description": "Shows the most played songs in this server",
+    "options": [
+      {
+        "name": "limit",
+        "type": 4,
+        "description": "Number of songs to show (default 10, max 25)",
+        "required": false,
+        "min_value": 1,
+        "max_value": 25
+      }
+    ]
   }
 ]

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -182,6 +182,10 @@ func NewController(db *database.Database) (*Controller, error) {
 	}, nil
 }
 
+func (c *Controller) GetDB() *database.Database {
+	return c.db
+}
+
 func (c *Controller) GetPlayer(guildID string) *GuildPlayer {
 	if session, ok := c.sessions[guildID]; ok {
 		return session


### PR DESCRIPTION
/history shows recently played songs with who requested them and when. /leaderboard shows most played songs with medal icons for the top 3. Both guild-scoped, multi-server safe, with optional limit param (1-25).

Built on top of the SQLite persistence layer from PR #36.

Closes BEN-11