### PR TITLE
feat: auto-register slash commands on container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,10 @@ RUN useradd -m -u 1000 -s /bin/bash appuser
 
 WORKDIR /app
 
-# Copy binary from builder
+# Copy binary and startup files from builder
 COPY --from=builder /app/discord-bot .
+COPY --from=builder /app/commands.json .
+COPY --from=builder /app/entrypoint.sh .
 
 # Create data directory for SQLite persistence
 RUN mkdir -p /app/data
@@ -66,4 +68,4 @@ VOLUME /app/data
 
 EXPOSE 8080
 
-CMD ["./discord-bot"]
+CMD ["./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+# Register slash commands with Discord on startup
+if [ -n "$DISCORD_BOT_TOKEN" ] && [ -n "$DISCORD_APP_ID" ]; then
+  echo "Registering Discord commands..."
+  curl -sf -X PUT \
+    -H "Authorization: Bot $DISCORD_BOT_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d @commands.json \
+    "https://discord.com/api/v10/applications/$DISCORD_APP_ID/commands" > /dev/null
+  echo "Commands registered."
+else
+  echo "Warning: DISCORD_BOT_TOKEN or DISCORD_APP_ID not set, skipping command registration."
+fi
+
+exec ./discord-bot


### PR DESCRIPTION
Adds an entrypoint script that registers Discord slash commands via the API before starting the bot. No more manually running `set-commands.sh` after adding new commands -- every container restart ensures commands are in sync.

- `entrypoint.sh` calls the Discord PUT endpoint with `commands.json`
- Gracefully skips if env vars aren't set
- `exec`s the bot binary so signals propagate correctly