### PR TITLE
fix: remove commands.json from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -61,7 +61,6 @@ Jenkinsfile
 
 # Development scripts
 set-commands.sh
-commands.json
 
 # OS files
 Thumbs.db


### PR DESCRIPTION
commands.json was in .dockerignore, which broke the auto-registration entrypoint from PR #38. The COPY command couldn't find the file during Docker build.