### PR TITLE
feat: Implement Apple Music Phase 2 - Album & Playlist support

### DIFF
--- a/applemusic/client.go
+++ b/applemusic/client.go
@@ -3,6 +3,7 @@ package applemusic
 import (
 	"context"
 	"errors"
+	"strconv"
 
 	sentry "github.com/getsentry/sentry-go"
 	log "github.com/sirupsen/logrus"
@@ -49,17 +50,101 @@ func GetTrack(ctx context.Context, country, albumID, trackID string) (*TrackInfo
 }
 
 // GetAlbumTracks fetches album metadata and tracks from Apple Music
-// Phase 2 - Not implemented yet
 func GetAlbumTracks(ctx context.Context, country, albumID string) (*AlbumResult, error) {
-	log.Warnf("GetAlbumTracks not yet implemented for album %s", albumID)
-	return nil, errors.New("album parsing not implemented yet")
+	log.Tracef("Fetching album from Apple Music: country=%s, album=%s", country, albumID)
+
+	span := sentry.StartSpan(ctx, "applemusic.get_album_tracks")
+	span.Description = "Get album tracks from Apple Music via web scraping"
+	span.SetTag("country", country)
+	span.SetTag("album_id", albumID)
+	defer span.Finish()
+
+	if country == "" {
+		country = "us"
+	}
+	if albumID == "" {
+		err := errors.New("albumID is required")
+		sentry.CaptureException(err)
+		span.Status = sentry.SpanStatusInvalidArgument
+		return nil, err
+	}
+
+	albumResult, err := scrapeAlbumTracks(ctx, country, albumID)
+	if err != nil {
+		log.Errorf("Failed to fetch Apple Music album: %v", err)
+		sentry.CaptureException(err)
+		span.Status = sentry.SpanStatusInternalError
+		return nil, err
+	}
+
+	if len(albumResult.Tracks) == 0 {
+		err := errors.New("album has no playable tracks")
+		log.Warnf("Album %s has no tracks", albumID)
+		sentry.CaptureException(err)
+		span.Status = sentry.SpanStatusNotFound
+		return nil, err
+	}
+
+	log.Debugf("Successfully fetched Apple Music album: '%s' by %s (%d tracks)",
+		albumResult.Name, albumResult.Artist, len(albumResult.Tracks))
+	span.Status = sentry.SpanStatusOK
+	span.SetData("album_name", albumResult.Name)
+	span.SetData("artist", albumResult.Artist)
+	span.SetData("tracks_count", len(albumResult.Tracks))
+	span.SetData("total_tracks", albumResult.TotalTracks)
+
+	return albumResult, nil
 }
 
 // GetPlaylistTracks fetches playlist metadata and tracks from Apple Music
-// Phase 2 - Not implemented yet
 func GetPlaylistTracks(ctx context.Context, country, playlistID string, limit int) (*PlaylistResult, error) {
-	log.Warnf("GetPlaylistTracks not yet implemented for playlist %s", playlistID)
-	return nil, errors.New("playlist parsing not implemented yet")
+	log.Tracef("Fetching playlist from Apple Music: country=%s, playlist=%s, limit=%d",
+		country, playlistID, limit)
+
+	span := sentry.StartSpan(ctx, "applemusic.get_playlist_tracks")
+	span.Description = "Get playlist tracks from Apple Music via web scraping"
+	span.SetTag("country", country)
+	span.SetTag("playlist_id", playlistID)
+	span.SetTag("limit", strconv.Itoa(limit))
+	defer span.Finish()
+
+	if country == "" {
+		country = "us"
+	}
+	if playlistID == "" {
+		err := errors.New("playlistID is required")
+		sentry.CaptureException(err)
+		span.Status = sentry.SpanStatusInvalidArgument
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 15
+	}
+
+	playlistResult, err := scrapePlaylistTracks(ctx, country, playlistID, limit)
+	if err != nil {
+		log.Errorf("Failed to fetch Apple Music playlist: %v", err)
+		sentry.CaptureException(err)
+		span.Status = sentry.SpanStatusInternalError
+		return nil, err
+	}
+
+	if len(playlistResult.Tracks) == 0 {
+		err := errors.New("playlist has no playable tracks")
+		log.Warnf("Playlist %s has no tracks", playlistID)
+		sentry.CaptureException(err)
+		span.Status = sentry.SpanStatusNotFound
+		return nil, err
+	}
+
+	log.Debugf("Successfully fetched Apple Music playlist: '%s' (%d tracks)",
+		playlistResult.Name, len(playlistResult.Tracks))
+	span.Status = sentry.SpanStatusOK
+	span.SetData("playlist_name", playlistResult.Name)
+	span.SetData("tracks_count", len(playlistResult.Tracks))
+	span.SetData("total_tracks", playlistResult.TotalTracks)
+
+	return playlistResult, nil
 }
 
 // GetArtistTopSongs fetches top songs for an artist from Apple Music

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -255,15 +255,15 @@ func (manager *Manager) QueryAndQueue(ctx context.Context, transaction *sentry.S
 			return
 		}
 
-		// Handle playlists (Phase 2 - not implemented yet)
+		// Handle playlists
 		if appleMusicReq.PlaylistID != "" {
-			manager.SendFollowup(ctx, interaction, "", "Apple Music playlists are coming soon!", true)
+			manager.handleAppleMusicPlaylist(ctx, interaction, player, appleMusicReq)
 			return
 		}
 
-		// Handle albums (Phase 2 - not implemented yet)
+		// Handle albums
 		if appleMusicReq.AlbumID != "" && appleMusicReq.TrackID == "" {
-			manager.SendFollowup(ctx, interaction, "", "Apple Music albums are coming soon!", true)
+			manager.handleAppleMusicAlbum(ctx, interaction, player, appleMusicReq)
 			return
 		}
 
@@ -353,6 +353,16 @@ func (c SpotifyCollection) DisplayName() string {
 		return fmt.Sprintf("%s by %s", c.Name, c.Artist)
 	}
 	return c.Name
+}
+
+// AppleMusicCollection represents an album or playlist for processing
+type AppleMusicCollection struct {
+	Type        string // "album" or "playlist"
+	ID          string
+	Name        string
+	Artist      string // Only for albums
+	Tracks      []applemusic.PlaylistTrackInfo
+	TotalTracks int
 }
 
 // handleSpotifyCollection processes tracks from a Spotify playlist or album
@@ -742,6 +752,246 @@ func (manager *Manager) handleAppleMusicTrack(ctx context.Context, interaction *
 	manager.SendFollowup(ctx, interaction, followUpMessage, followUpMessage, false)
 
 	player.Add(ctx, video, interaction.Member.User.ID, interaction.Token, manager.AppID)
+}
+
+// handleAppleMusicAlbum processes an Apple Music album
+func (manager *Manager) handleAppleMusicAlbum(ctx context.Context, interaction *Interaction, player *controller.GuildPlayer, req applemusic.AppleMusicRequest) {
+	log.Debugf("Processing Apple Music album: country=%s, album=%s", req.Country, req.AlbumID)
+
+	manager.SendFollowup(ctx, interaction, "", "Found an Apple Music album, fetching tracks...", false)
+
+	sentryhelper.AddBreadcrumb(ctx, &sentry.Breadcrumb{
+		Category: "applemusic_album",
+		Message:  "Fetching Apple Music album: " + req.AlbumID,
+		Level:    sentry.LevelInfo,
+	})
+
+	country := req.Country
+	if country == "" {
+		country = "us"
+	}
+
+	albumResult, err := applemusic.GetAlbumTracks(ctx, country, req.AlbumID)
+	if err != nil {
+		log.Errorf("Error fetching Apple Music album: %v", err)
+		sentryhelper.CaptureException(ctx, err)
+
+		errMsg := err.Error()
+		switch {
+		case strings.Contains(errMsg, "404"):
+			manager.SendFollowup(ctx, interaction, "", "That album doesn't exist or has been deleted.", true)
+		case strings.Contains(errMsg, "403"):
+			manager.SendFollowup(ctx, interaction, "", "That album is not accessible.", true)
+		case strings.Contains(errMsg, "no playable tracks"):
+			manager.SendFollowup(ctx, interaction, "", "That album contains no playable tracks.", true)
+		default:
+			manager.SendFollowup(ctx, interaction, "", "Error fetching album from Apple Music: "+errMsg, true)
+		}
+		return
+	}
+
+	sentryhelper.AddBreadcrumb(ctx, &sentry.Breadcrumb{
+		Category: "applemusic_album",
+		Message:  fmt.Sprintf("Fetched %d tracks from album '%s' by %s", len(albumResult.Tracks), albumResult.Name, albumResult.Artist),
+		Level:    sentry.LevelInfo,
+		Data: map[string]interface{}{
+			"album_id":     req.AlbumID,
+			"album_name":   albumResult.Name,
+			"artist":       albumResult.Artist,
+			"track_count":  len(albumResult.Tracks),
+			"total_tracks": albumResult.TotalTracks,
+		},
+	})
+
+	manager.handleAppleMusicCollection(ctx, interaction, player, AppleMusicCollection{
+		Type:        "album",
+		ID:          req.AlbumID,
+		Name:        albumResult.Name,
+		Artist:      albumResult.Artist,
+		Tracks:      albumResult.Tracks,
+		TotalTracks: albumResult.TotalTracks,
+	})
+}
+
+// handleAppleMusicPlaylist processes an Apple Music playlist
+func (manager *Manager) handleAppleMusicPlaylist(ctx context.Context, interaction *Interaction, player *controller.GuildPlayer, req applemusic.AppleMusicRequest) {
+	log.Debugf("Processing Apple Music playlist: country=%s, playlist=%s", req.Country, req.PlaylistID)
+
+	manager.SendFollowup(ctx, interaction, "", "Found an Apple Music playlist, fetching tracks...", false)
+
+	sentryhelper.AddBreadcrumb(ctx, &sentry.Breadcrumb{
+		Category: "applemusic_playlist",
+		Message:  "Fetching Apple Music playlist: " + req.PlaylistID,
+		Level:    sentry.LevelInfo,
+	})
+
+	country := req.Country
+	if country == "" {
+		country = "us"
+	}
+
+	limit := 15
+
+	playlistResult, err := applemusic.GetPlaylistTracks(ctx, country, req.PlaylistID, limit)
+	if err != nil {
+		log.Errorf("Error fetching Apple Music playlist: %v", err)
+		sentryhelper.CaptureException(ctx, err)
+
+		errMsg := err.Error()
+		switch {
+		case strings.Contains(errMsg, "404"):
+			manager.SendFollowup(ctx, interaction, "", "That playlist doesn't exist or has been deleted.", true)
+		case strings.Contains(errMsg, "403") || strings.Contains(errMsg, "private"):
+			manager.SendFollowup(ctx, interaction, "", "That playlist is private. Make it public or use track URLs instead.", true)
+		case strings.Contains(errMsg, "no playable tracks"):
+			manager.SendFollowup(ctx, interaction, "", "That playlist contains no playable tracks.", true)
+		default:
+			manager.SendFollowup(ctx, interaction, "", "Error fetching playlist from Apple Music: "+errMsg, true)
+		}
+		return
+	}
+
+	sentryhelper.AddBreadcrumb(ctx, &sentry.Breadcrumb{
+		Category: "applemusic_playlist",
+		Message:  fmt.Sprintf("Fetched %d tracks from playlist '%s'", len(playlistResult.Tracks), playlistResult.Name),
+		Level:    sentry.LevelInfo,
+		Data: map[string]interface{}{
+			"playlist_id":   req.PlaylistID,
+			"playlist_name": playlistResult.Name,
+			"track_count":   len(playlistResult.Tracks),
+			"total_tracks":  playlistResult.TotalTracks,
+		},
+	})
+
+	manager.handleAppleMusicCollection(ctx, interaction, player, AppleMusicCollection{
+		Type:        "playlist",
+		ID:          req.PlaylistID,
+		Name:        playlistResult.Name,
+		Tracks:      playlistResult.Tracks,
+		TotalTracks: playlistResult.TotalTracks,
+	})
+}
+
+// handleAppleMusicCollection processes tracks from an Apple Music album or playlist
+func (manager *Manager) handleAppleMusicCollection(ctx context.Context, interaction *Interaction, player *controller.GuildPlayer, collection AppleMusicCollection) {
+	category := "applemusic_" + collection.Type
+
+	breadcrumbData := map[string]interface{}{
+		collection.Type + "_id":   collection.ID,
+		collection.Type + "_name": collection.Name,
+		"track_count":             len(collection.Tracks),
+		"total_tracks":            collection.TotalTracks,
+	}
+	if collection.Artist != "" {
+		breadcrumbData["artist"] = collection.Artist
+	}
+
+	sentryhelper.AddBreadcrumb(ctx, &sentry.Breadcrumb{
+		Category: category,
+		Message:  fmt.Sprintf("Fetched %d tracks from %s '%s'", len(collection.Tracks), collection.Type, collection.Name),
+		Level:    sentry.LevelInfo,
+		Data:     breadcrumbData,
+	})
+
+	searchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	searchSpan := sentry.StartSpan(searchCtx, "youtube.parallel_search")
+	searchSpan.Description = fmt.Sprintf("Parallel YouTube search for Apple Music %s tracks", collection.Type)
+	searchSpan.SetTag("track_count", strconv.Itoa(len(collection.Tracks)))
+
+	results := make(chan searchResult, len(collection.Tracks))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 10)
+
+	for i, track := range collection.Tracks {
+		wg.Add(1)
+		go func(position int, track applemusic.PlaylistTrackInfo) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			artistsStr := strings.Join(track.Artists, ", ")
+			query := artistsStr + " - " + track.Title
+
+			videos := youtube.Query(searchCtx, query)
+
+			if len(videos) > 0 {
+				results <- searchResult{
+					Position: position,
+					Video:    videos[0],
+					Query:    query,
+					Found:    true,
+				}
+			} else {
+				log.Warnf("No YouTube results for Apple Music %s track: %s", collection.Type, query)
+				results <- searchResult{
+					Position: position,
+					Query:    query,
+					Found:    false,
+				}
+			}
+		}(i, track)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	var searchResults []searchResult
+	for result := range results {
+		searchResults = append(searchResults, result)
+	}
+
+	searchSpan.Finish()
+
+	sort.Slice(searchResults, func(i, j int) bool {
+		return searchResults[i].Position < searchResults[j].Position
+	})
+
+	var foundVideos []youtube.VideoResponse
+	var notFoundQueries []string
+	for _, r := range searchResults {
+		if r.Found {
+			foundVideos = append(foundVideos, r.Video)
+		} else {
+			notFoundQueries = append(notFoundQueries, r.Query)
+		}
+	}
+
+	log.Debugf("Found %d/%d tracks on YouTube for Apple Music %s '%s'",
+		len(foundVideos), len(collection.Tracks), collection.Type, collection.Name)
+
+	if len(foundVideos) == 0 {
+		manager.SendFollowup(ctx, interaction, "",
+			fmt.Sprintf("Couldn't find any tracks from **%s** on YouTube", collection.Name),
+			true)
+		return
+	}
+
+	var collectionDescription string
+	if collection.Type == "album" {
+		collectionDescription = fmt.Sprintf("**%s** by **%s**", collection.Name, collection.Artist)
+	} else {
+		collectionDescription = fmt.Sprintf("**%s**", collection.Name)
+	}
+
+	summaryMsg := fmt.Sprintf("Adding %d/%d tracks from %s %s to the queue",
+		len(foundVideos), collection.TotalTracks, collection.Type, collectionDescription)
+
+	if len(notFoundQueries) > 0 {
+		summaryMsg += fmt.Sprintf("\n\n⚠️ Couldn't find %d tracks on YouTube", len(notFoundQueries))
+	}
+
+	manager.SendFollowup(ctx, interaction, "", summaryMsg, false)
+
+	for _, video := range foundVideos {
+		player.Add(ctx, video, interaction.Member.User.ID, interaction.Token, manager.AppID)
+	}
+
+	log.Infof("Queued %d tracks from Apple Music %s '%s' for user %s",
+		len(foundVideos), collection.Type, collection.Name, interaction.Member.User.ID)
 }
 
 func (manager *Manager) handleYouTubePlaylist(ctx context.Context, interaction *Interaction, player *controller.GuildPlayer, playlistID string) {


### PR DESCRIPTION
This commit adds full album and playlist support for Apple Music URLs, completing Phase 2 of the Apple Music integration.

## Changes

### applemusic/scraper.go (~350 LOC added)
- Add scrapeAlbumTracks() - Fetches album page and extracts track list
- Add extractAlbumFromJSONLD() - Parses MusicAlbum JSON-LD schema
- Add extractAlbumFromHTML() - HTML fallback for albums
- Add scrapePlaylistTracks() - Fetches playlist page and extracts tracks
- Add extractPlaylistFromJSONLD() - Parses MusicPlaylist JSON-LD schema
- Add extractPlaylistFromHTML() - HTML fallback for playlists
- Track limit: 15 for albums, configurable for playlists (default 15)

### applemusic/client.go (~100 LOC added)
- Implement GetAlbumTracks() - Full implementation with Sentry spans
- Implement GetPlaylistTracks() - Full implementation with Sentry spans
- Add strconv import for SetTag() with limit parameter
- Comprehensive error handling and validation

### handlers/handlers.go (~240 LOC added)
- Add AppleMusicCollection type (mirrors SpotifyCollection)
- Add handleAppleMusicAlbum() - Processes album URLs
- Add handleAppleMusicAlbum() - Processes playlist URLs
- Add handleAppleMusicCollection() - Shared logic for parallel YouTube search
- Update routing to call new handlers (removed 'coming soon' placeholders)
- Parallel YouTube search with semaphore (10 concurrent)
- Proper error messages for 404/403/empty collections

## Technical Approach
- Primary: JSON-LD structured data (@type: MusicAlbum/MusicPlaylist)
- Fallback: HTML parsing with .songs-list-row selectors
- Mirrors Spotify integration pattern exactly
- 15 track limit for albums, configurable for playlists

## Error Handling
- HTTP 404: "That {type} doesn't exist or has been deleted."
- HTTP 403: "That {type} is not accessible." / "That playlist is private."
- Empty collections: "That {type} contains no playable tracks."
- Partial YouTube matches: "⚠️ Couldn't find {count} tracks on YouTube"

## Testing
- Code formatted with gofmt
- Compilation verified (applemusic package builds successfully)
- Follows established patterns from Phase 1 and Spotify integration

Closes: Apple Music Phase 2 implementation
Related: PR #43 (Phase 1 - Track support)