### PR TITLE
feat(now-playing): Phase 2 - Integration with playback events

### DIFF
--- a/discord/messages.go
+++ b/discord/messages.go
@@ -4,10 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 
+	"beatbot/config"
 	"beatbot/gemini"
 
+	"github.com/bwmarrin/discordgo"
 	sentry "github.com/getsentry/sentry-go"
 	log "github.com/sirupsen/logrus"
 )
@@ -97,4 +101,113 @@ func UpdateMessage(request *FollowUpRequest) {
 		return
 	}
 	defer resp.Body.Close()
+}
+
+// SendChannelMessage sends a new message to a channel using bot token
+// Returns the created message for storing the message ID
+func SendChannelMessage(channelID, content string, embed *discordgo.MessageEmbed, components []discordgo.MessageComponent) (*discordgo.Message, error) {
+	payload := map[string]interface{}{}
+
+	if content != "" {
+		payload["content"] = content
+	}
+
+	if embed != nil {
+		payload["embeds"] = []*discordgo.MessageEmbed{embed}
+	}
+
+	if components != nil {
+		payload["components"] = components
+	}
+
+	jsonPayload, err := json.Marshal(payload)
+	if err != nil {
+		sentry.CaptureException(err)
+		return nil, err
+	}
+
+	url := fmt.Sprintf("https://discord.com/api/v10/channels/%s/messages", channelID)
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		sentry.CaptureException(err)
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bot %s", config.Config.Discord.BotToken))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		sentry.CaptureException(err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		err := fmt.Errorf("failed to send message: %s - %s", resp.Status, string(body))
+		log.Error(err)
+		return nil, err
+	}
+
+	var message discordgo.Message
+	if err := json.NewDecoder(resp.Body).Decode(&message); err != nil {
+		sentry.CaptureException(err)
+		return nil, err
+	}
+
+	return &message, nil
+}
+
+// EditChannelMessage updates an existing message in a channel using bot token
+// Used for updating now-playing cards without the 15-minute webhook token limit
+func EditChannelMessage(channelID, messageID string, content string, embed *discordgo.MessageEmbed, components []discordgo.MessageComponent) error {
+	payload := map[string]interface{}{}
+
+	if content != "" {
+		payload["content"] = content
+	}
+
+	if embed != nil {
+		payload["embeds"] = []*discordgo.MessageEmbed{embed}
+	}
+
+	if components != nil {
+		payload["components"] = components
+	}
+
+	jsonPayload, err := json.Marshal(payload)
+	if err != nil {
+		sentry.CaptureException(err)
+		log.Errorf("Error marshalling payload: %v", err)
+		return err
+	}
+
+	url := fmt.Sprintf("https://discord.com/api/v10/channels/%s/messages/%s", channelID, messageID)
+
+	req, err := http.NewRequest("PATCH", url, bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		sentry.CaptureException(err)
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bot %s", config.Config.Discord.BotToken))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		sentry.CaptureException(err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		err := fmt.Errorf("failed to edit message: %s - %s", resp.Status, string(body))
+		log.Error(err)
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Phase 2: Now-Playing Card Integration

Builds on Phase 1 (embeds, components, position tracking) to integrate now-playing cards into the playback flow.

### Changes:
- ✅ `SendChannelMessage()` and `EditChannelMessage()` in `discord/messages.go`
- ✅ Now-playing state fields in `GuildPlayer`
- ✅ Card lifecycle methods: send, update, start/stop updates, clear
- ✅ Event hooks: PlaybackStarted, Paused, Resumed, Completed, Stopped
- ✅ 5-second progress update loop
- ✅ Mutex protection for thread-safety

### Testing:
Manual testing required:
- [ ] Card appears on playback start
- [ ] Progress bar updates every 5 seconds
- [ ] Pause/resume updates button state
- [ ] Skip/stop clears card properly
- [ ] No goroutine leaks

### Implementation Details:

#### discord/messages.go
- Added `SendChannelMessage()` - sends new message to channel using bot token, returns message for storing ID
- Added `EditChannelMessage()` - updates existing message using bot token (no 15-minute webhook limit)

#### controller/controller.go
- Added 5 new fields to `GuildPlayer` struct for now-playing card state tracking
- Implemented `sendNowPlayingCard()` - creates and sends initial now-playing card
- Implemented `updateNowPlayingCard()` - updates card with current progress and state
- Implemented `startNowPlayingUpdates()` - spawns goroutine for 5-second update loop
- Implemented `stopNowPlayingUpdates()` - cleanly stops update loop
- Implemented `clearNowPlayingCard()` - clears card state
- Hooked into `listenForPlaybackEvents()`:
  - PlaybackStarted → send card
  - PlaybackPaused/Resumed → update button state
  - PlaybackCompleted/Stopped → stop updates and clear

### Concurrency Safety:
- `nowPlayingMutex` protects all card state modifications
- Update goroutine stops cleanly via `nowPlayingUpdateStop` channel
- No race conditions between events

### Next: Phase 3 (Button Interactions)