### PR TITLE
test: add high-priority unit tests

### DIFF
--- a/applemusic/applemusic_test.go
+++ b/applemusic/applemusic_test.go
@@ -1,0 +1,67 @@
+package applemusic
+
+import (
+	"testing"
+)
+
+func TestParseAppleMusicURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		want    AppleMusicRequest
+		wantErr bool
+	}{
+		{
+			name: "album us",
+			url:  "https://music.apple.com/us/album/the-dark-side-of-the-moon/1441165866",
+			want: AppleMusicRequest{Country: "us", AlbumID: "1441165866"},
+		},
+		{
+			name: "playlist pl prefix",
+			url:  "https://music.apple.com/us/playlist/90s-alternative/pl.u-8VoLGjY1l8l5l5l5l5",
+			want: AppleMusicRequest{Country: "us", PlaylistID: "pl.u-8VoLGjY1l8l5l5l5l5"},
+		},
+		{
+			name: "track with i query",
+			url:  "https://music.apple.com/us/album/album-name/123456789?i=1646389445",
+			want: AppleMusicRequest{Country: "us", AlbumID: "123456789", TrackID: "1646389445"},
+		},
+		{
+			name: "itunes domain",
+			url:  "https://itunes.apple.com/us/album/album-name/123456789",
+			want: AppleMusicRequest{Country: "us", AlbumID: "123456789"},
+		},
+		{
+			name: "uk country",
+			url:  "https://music.apple.com/gb/album/album-name/123456789",
+			want: AppleMusicRequest{Country: "gb", AlbumID: "123456789"},
+		},
+		{
+			name:    "invalid no apple.com",
+			url:     "https://example.com/album/id123",
+			want:    AppleMusicRequest{},
+			wantErr: true,
+		},
+		{
+			name:    "no id",
+			url:     "https://music.apple.com/us/album/no-id-here",
+			want:    AppleMusicRequest{Country: "us"},
+			wantErr: true, // no ID extracted
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseAppleMusicURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseAppleMusicURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ParseAppleMusicURL() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,103 @@
+package config
+
+import "testing"
+
+func TestGetIdleTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"empty", "", 20},
+		{"invalid", "abc", 20},
+		{"zero", "0", 20},
+		{"negative", "-1", 20},
+		{"valid_small", "10", 10},
+		{"valid_default", "20", 20},
+		{"valid_large", "30", 30},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("IDLE_TIMEOUT_MINUTES", tt.env)
+			if got := getIdleTimeout(); got != tt.want {
+				t.Errorf("getIdleTimeout() = %d; want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetPlaylistLimit(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"empty", "", 10},
+		{"invalid", "foo", 10},
+		{"zero", "0", 10},
+		{"negative", "-10", 10},
+		{"min", "1", 1},
+		{"mid", "25", 25},
+		{"max", "50", 50},
+		{"over", "51", 50},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("SPOTIFY_PLAYLIST_LIMIT", tt.env)
+			if got := getPlaylistLimit(); got != tt.want {
+				t.Errorf("getPlaylistLimit() = %d; want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetYouTubePlaylistLimit(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"empty", "", 15},
+		{"invalid", "foo", 15},
+		{"zero", "0", 15},
+		{"negative", "-10", 15},
+		{"min", "1", 1},
+		{"mid", "25", 25},
+		{"max", "50", 50},
+		{"over", "51", 50},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("YOUTUBE_PLAYLIST_LIMIT", tt.env)
+			if got := getYouTubePlaylistLimit(); got != tt.want {
+				t.Errorf("getYouTubePlaylistLimit() = %d; want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetAudioBitrate(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"empty", "", 128000},
+		{"invalid", "foo", 128000},
+		{"zero", "0", 128000},
+		{"negative", "-100", 128000},
+		{"below_min", "7000", 8000},
+		{"min", "8000", 8000},
+		{"default", "128000", 128000},
+		{"high", "300000", 300000},
+		{"above_max", "600000", 512000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("AUDIO_BITRATE", tt.env)
+			if got := getAudioBitrate(); got != tt.want {
+				t.Errorf("getAudioBitrate() = %d; want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1,0 +1,80 @@
+package controller
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestSongHistory(t *testing.T) {
+	sh := NewSongHistory(3)
+
+	entries := []SongHistoryEntry{
+		{VideoID: "1", Title: "Song 1"},
+		{VideoID: "2", Title: "Song 2"},
+		{VideoID: "3", Title: "Song 3"},
+		{VideoID: "4", Title: "Song 4"}, // This should cause wrap-around
+	}
+
+	for i, e := range entries {
+		sh.Add(e)
+		t.Run(fmt.Sprintf("AfterAdd%d", i+1), func(t *testing.T) {
+			expectedLen := min(3, i+1)
+			if got := sh.Len(); got != expectedLen {
+				t.Errorf("Len() = %d, want %d", got, expectedLen)
+			}
+		})
+	}
+
+	// Test GetRecent
+	recent := sh.GetRecent(2)
+	if len(recent) != 2 || recent[0].VideoID != "3" || recent[1].VideoID != "4" {
+		t.Errorf("GetRecent(2) = %v, want last 2: 3,4", recent)
+	}
+
+	recentAll := sh.GetRecent(10) // more than size
+	if len(recentAll) != 3 {
+		t.Errorf("GetRecent(10) len=%d, want 3", len(recentAll))
+	}
+
+	// Test GetAllVideoIDs
+	ids := sh.GetAllVideoIDs()
+	expectedIDs := map[string]bool{"2": true, "3": true, "4": true}
+	if len(ids) != 3 || !ids["2"] || !ids["3"] || !ids["4"] {
+		t.Errorf("GetAllVideoIDs() = %v, want %v", ids, expectedIDs)
+	}
+}
+
+func TestGuildPlayerIsEmpty(t *testing.T) {
+	player := &GuildPlayer{
+		Queue: &GuildQueue{},
+	}
+
+	if !player.IsEmpty() {
+		t.Error("expected empty queue")
+	}
+
+	player.Queue.Items = append(player.Queue.Items, &GuildQueueItem{})
+
+	if player.IsEmpty() {
+		t.Error("expected non-empty queue")
+	}
+
+	// Test race condition mentally: lock protects
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			player.IsEmpty()
+		}()
+	}
+	wg.Wait()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/spotify/spotify_test.go
+++ b/spotify/spotify_test.go
@@ -1,0 +1,73 @@
+package spotify
+
+import (
+	"testing"
+)
+
+func TestParseSpotifyURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		want    SpotifyRequest
+		wantErr bool
+	}{
+		{
+			name: "track",
+			url:  "https://open.spotify.com/track/0VjIjW4GlUZAMYd2vXMi3b",
+			want: SpotifyRequest{TrackID: "0VjIjW4GlUZAMYd2vXMi3b"},
+		},
+		{
+			name: "track with si query",
+			url:  "https://open.spotify.com/track/0VjIjW4GlUZAMYd2vXMi3b?si=abc123",
+			want: SpotifyRequest{TrackID: "0VjIjW4GlUZAMYd2vXMi3b"},
+		},
+		{
+			name: "playlist",
+			url:  "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M",
+			want: SpotifyRequest{PlaylistID: "37i9dQZF1DXcBWIGoYBM5M"},
+		},
+		{
+			name: "album",
+			url:  "https://open.spotify.com/album/4yP0hdKOZPNshxUOjY0cZj",
+			want: SpotifyRequest{AlbumID: "4yP0hdKOZPNshxUOjY0cZj"},
+		},
+		{
+			name: "artist",
+			url:  "https://open.spotify.com/artist/4NHQPlJsbc7kbJTwq0B3lD",
+			want: SpotifyRequest{ArtistID: "4NHQPlJsbc7kbJTwq0B3lD"},
+		},
+		{
+			name:    "invalid domain",
+			url:     "https://example.com/track/abc",
+			want:    SpotifyRequest{},
+			wantErr: true,
+		},
+		{
+			name:    "missing id",
+			url:     "https://open.spotify.com/track/",
+			want:    SpotifyRequest{TrackID: ""},
+			wantErr: false,
+		},
+		{
+			name:    "wrong path",
+			url:     "https://open.spotify.com/wrong/abc",
+			want:    SpotifyRequest{},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseSpotifyURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseSpotifyURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ParseSpotifyURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/youtube/youtube_test.go
+++ b/youtube/youtube_test.go
@@ -1,0 +1,113 @@
+package youtube
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseYouTubeURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want YouTubeURLResult
+	}{
+		{
+			name: "watch video",
+			url:  "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+			want: YouTubeURLResult{VideoID: "dQw4w9WgXcQ"},
+		},
+		{
+			name: "watch video with playlist",
+			url:  "https://www.youtube.com/watch?v=abc123&list=PLdef456",
+			want: YouTubeURLResult{VideoID: "abc123", PlaylistID: "PLdef456"},
+		},
+		{
+			name: "playlist",
+			url:  "https://youtube.com/playlist?list=PL123456",
+			want: YouTubeURLResult{PlaylistID: "PL123456"},
+		},
+		{
+			name: "youtu.be short",
+			url:  "https://youtu.be/dQw4w9WgXcQ",
+			want: YouTubeURLResult{},
+		},
+		{
+			name: "invalid host",
+			url:  "https://example.com/watch?v=abc",
+			want: YouTubeURLResult{},
+		},
+		{
+			name: "malformed URL",
+			url:  "invalid-url",
+			want: YouTubeURLResult{},
+		},
+		{
+			name: "empty query",
+			url:  "https://www.youtube.com/",
+			want: YouTubeURLResult{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseYouTubeURL(tt.url); got != tt.want {
+				t.Errorf("ParseYouTubeURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseYoutubeDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		iso  string
+		want time.Duration
+	}{
+		{
+			name: "1min 30s",
+			iso:  "PT1M30S",
+			want: 90 * time.Second,
+		},
+		{
+			name: "1 hour",
+			iso:  "PT1H",
+			want: 1 * time.Hour,
+		},
+		{
+			name: "30 seconds",
+			iso:  "PT30S",
+			want: 30 * time.Second,
+		},
+		{
+			name: "1h30m45s",
+			iso:  "PT1H30M45S",
+			want: 1*time.Hour + 30*time.Minute + 45*time.Second,
+		},
+		{
+			name: "1h2m",
+			iso:  "PT1H2M",
+			want: 1*time.Hour + 2*time.Minute,
+		},
+		{
+			name: "invalid",
+			iso:  "invalid",
+			want: 0,
+		},
+		{
+			name: "empty",
+			iso:  "",
+			want: 0,
+		},
+		{
+			name: "only seconds",
+			iso:  "PT0S",
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseYoutubeDuration(tt.iso); got != tt.want {
+				t.Errorf("parseYoutubeDuration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds unit tests for 5 packages:

- **config** — env parsing helpers (idle timeout, playlist limits, audio bitrate)
- **youtube** — URL parsing and ISO duration parsing
- **spotify** — ParseSpotifyURL across track/playlist/album/artist
- **applemusic** — URL parsing including playlists, track IDs, iTunes domains, country codes
- **controller** — SongHistory ring buffer, race-safe

All table-driven, zero new dependencies, passes `go test ./... -race`.