### PR TITLE
fix: always use SetBitrateToMax, remove dynamic channel bitrate

### DIFF
--- a/audio/player.go
+++ b/audio/player.go
@@ -359,17 +359,6 @@ func (p *Player) GetVolume() int {
 	return p.volume
 }
 
-// SetEncoderBitrate updates the Opus encoder bitrate to match the Discord
-// voice channel's configured bitrate. Boosted servers support higher limits
-// (128k → 256k → 384k), so this should be called whenever the bot joins or
-// rejoins a channel. Pass 0 to revert to the encoder's maximum.
-func (p *Player) SetEncoderBitrate(bps int) {
-	if bps <= 0 {
-		p.encoder.SetBitrateToMax()
-		return
-	}
-	p.encoder.SetBitrate(bps)
-}
 
 func (p *Player) GetPosition() time.Duration {
 	if p.playing == nil || !*p.playing {

--- a/audio/player.go
+++ b/audio/player.go
@@ -359,7 +359,6 @@ func (p *Player) GetVolume() int {
 	return p.volume
 }
 
-
 func (p *Player) GetPosition() time.Duration {
 	if p.playing == nil || !*p.playing {
 		return 0

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -545,25 +545,9 @@ func (p *GuildPlayer) JoinVoiceChannel(userID string) error {
 		},
 	})
 
-	p.applyChannelBitrate(voiceState.ChannelID)
-
 	log.Tracef("joined voice channel: %s", voiceState.ChannelID)
 
 	return nil
-}
-
-// applyChannelBitrate reads the Discord voice channel's configured bitrate and
-// updates the Opus encoder to match. This lets boosted servers automatically
-// benefit from higher quality (128k / 256k / 384k) without any manual config.
-func (p *GuildPlayer) applyChannelBitrate(channelID string) {
-	ch, err := p.Discord.Channel(channelID)
-	if err != nil || ch == nil || ch.Bitrate == 0 {
-		log.Warnf("[bitrate] could not fetch channel bitrate for %s, using encoder max: %v", channelID, err)
-		p.Player.SetEncoderBitrate(0) // falls back to SetBitrateToMax
-		return
-	}
-	log.Infof("[bitrate] setting encoder bitrate to %d bps (%d kbps) for channel %s", ch.Bitrate, ch.Bitrate/1000, channelID)
-	p.Player.SetEncoderBitrate(ch.Bitrate)
 }
 
 // getGuildName looks up the guild name from Discord, falling back to ID if unavailable
@@ -1540,9 +1524,6 @@ func (p *GuildPlayer) attemptVoiceRecovery() {
 		// Success! Update connection and resume
 		p.VoiceConnection = vc
 		log.Infof("Successfully reconnected to voice channel for guild %s", p.GuildID)
-
-		// Re-apply channel bitrate in case boost level changed during downtime
-		p.applyChannelBitrate(*currentChannelID)
 
 		// Reset reconnection attempts on success
 		p.reconnectAttempts = 0


### PR DESCRIPTION
Reverts the dynamic channel bitrate detection from #61.

The `applyChannelBitrate` approach was making things actively worse — Discord's default voice channel bitrate is 64 kbps, so the encoder was being capped there instead of running at max. The encoder doesn't need to know about Discord's delivery cap; Discord handles that on their end.

`SetBitrateToMax()` unconditionally. No config, no API calls, no surprises.