### PR TITLE
fix: wave 3 concurrency — listener goroutine stops, CurrentSong lock, non-blocking loader

### DIFF
--- a/audio/loader.go
+++ b/audio/loader.go
@@ -58,7 +58,7 @@ func (l *Loader) Load(ctx context.Context, job LoadJob) {
 	l.mutex.Lock()
 	defer func() {
 		l.mutex.Unlock()
-		l.completed <- true
+		select {	case l.completed <- true:	default:	}
 		span.Finish()
 	}()
 

--- a/audio/loader.go
+++ b/audio/loader.go
@@ -58,7 +58,10 @@ func (l *Loader) Load(ctx context.Context, job LoadJob) {
 	l.mutex.Lock()
 	defer func() {
 		l.mutex.Unlock()
-		select {	case l.completed <- true:	default:	}
+		select {
+		case l.completed <- true:
+		default:
+		}
 		span.Finish()
 	}()
 


### PR DESCRIPTION
Third and final wave of concurrency fixes from the planner audit.

## Changes

### 1. Listener goroutine leaks fixed
`listenForQueueEvents()`, `listenForLoadEvents()`, and `listenForPlaybackEvents()` previously used `for event := range ch` loops that never exited — goroutines leaked on idle, disconnect, or `Reset()`.

Replaced with `for { select { case event, ok := <-ch: ... case <-stopChan: return } }`. Three new stop channels added (`queueListenerStop`, `playbackListenerStop`, `loadListenerStop`), initialized in `GetPlayer()` and wired into `Reset()` with stop → remake → restart.

### 2. `CurrentSong *string` race fixed
Written from the playback event goroutine, read from handler goroutines without synchronization. Added `currentSongMutex sync.RWMutex`; all 8 access sites covered:
- 6 writes (PlaybackStarted/Stopped/Completed/Error, Reset, playNext) under `Lock/Unlock`
- 2 reads (handleAdd `shouldPlay` check, load event `CurrentSong == nil` check) under `RLock` — `handleAdd` uses an inline closure to avoid holding the lock across the unrelated `IsPlaying()` call

### 3. `Loader.completed` non-blocking
`l.completed <- true` at the end of a successful load blocked if the controller's receive had already moved on. Changed to `select { case l.completed <- true: default: }`.

---
Wave 1: #63 | Wave 2: #64 | Wave 3: this PR

All changes verified with `go test -race ./...` — no races, all packages pass.