### PR TITLE
fix(radio): dedup by title, skip re-triggers radio, better recommend logging

### DIFF
--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -160,6 +160,7 @@ Important:
 - Return ONLY the search query (e.g., "Artist Name - Song Title")
 - Do NOT include explanations, reasoning, or extra text
 - Do NOT suggest a song that's already in the list
+- Avoid recommending the same artist or song title as any entry in the recent history, even alternate versions or uploads.
 - The query should be specific enough to find the right song
 - Focus on musical similarity (genre, mood, tempo, style)
 


### PR DESCRIPTION
## Fixes

### Bug 1: Radio queues recently-played songs
VideoID-only dedup was failing for re-uploads and alt video IDs. Added `isRecentTitle()` helper that fuzzy-matches (lowercase `strings.Contains` both ways) against the last 5 history entries. All three pick loops in `queueRadioSong()` now check both VideoID and title. Also updated the Gemini prompt to explicitly avoid same artist/title variants.

### Bug 2: Skip with empty queue ignores radio mode
`EventSkip` was calling `playNext()` but not checking radio mode afterward. Natural song end already had this logic. Now mirrors it: if radio is on, queue is empty, and there's history after the skip, `queueRadioSong()` fires automatically.

### Bug 3: `/recommend` fails silently with no diagnostics
No logging between DB fetch → Gemini → YouTube meant we couldn't distinguish failure modes. Added structured log lines at each step. Also builds a `historyVideoIDs` set and skips already-played results — falls back to top result rather than erroring if everything's in history.

## Review
Passed code review — concurrency safe (`SongHistory` has internal mutex), no race conditions, consistent style.

## Files changed
- `controller/controller.go` — `isRecentTitle()` helper, title dedup in all pick loops, skip radio re-trigger
- `handlers/handlers.go` — recommend logging, VideoID dedup
- `gemini/gemini.go` — prompt tweak to avoid artist/title variants