### PR TITLE
feat: gracefully handle age-restricted YouTube videos

### DIFF
--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -151,13 +151,9 @@ func GenerateAgeRestrictedResponse(ctx context.Context, directRequest bool) stri
 
 	var instructions string
 	if directRequest {
-		instructions = `A user requested a specific YouTube video by URL and YouTube rejected it because it's age-restricted.
-Tell them the video is age-restricted and can't be played, and suggest they try a different link.
-Keep it short (one sentence), stay in character as a snarky DJ, and don't be preachy about it.`
+		instructions = `A user requested a specific YouTube video by URL and YouTube won't play it because it's age-restricted. Tell them in one sentence.`
 	} else {
-		instructions = `A user requested a song and YouTube blocked the result because it's "age-restricted".
-Tell them YouTube blocked it and suggest they try requesting something else.
-Keep it short (one sentence), stay in character as a snarky DJ, and don't lecture them.`
+		instructions = `A user requested a song and YouTube blocked it because it's "restricted". Tell them in one sentence and suggest they try something else.`
 	}
 
 	response := generateResponse(ctx, buildPrompt(instructions))


### PR DESCRIPTION
- Add ErrAgeRestricted sentinel in youtube package; no Sentry capture for expected failures
- Retry with up to 2 fallback search results before surfacing an error
- Direct URL requests get a hint that the specific video is age-restricted
- Search-result failures exhaust fallbacks then show a Gemini DJ response
- Add GenerateAgeRestrictedResponse to gemini package with direct/search prompt variants