### PR TITLE
fix: send helpful fallback message on 403 Missing Permissions (50013)

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1856,7 +1856,11 @@ func (p *GuildPlayer) sendNowPlayingCard(queueItem *GuildQueueItem) {
 	message, err := discord.SendChannelMessage(textCh, "", embed, nil)
 	if err != nil {
 		log.Errorf("Failed to send now-playing card: %v", err)
-		sentry.CaptureException(err)
+		if discord.IsMissingPermissions(err) {
+			discord.SendPermissionErrorFallback(textCh)
+		} else {
+			sentry.CaptureException(err)
+		}
 		return
 	}
 
@@ -2000,6 +2004,10 @@ func (p *GuildPlayer) startNowPlayingUpdates(queueItem *GuildQueueItem) {
 			case <-ticker.C:
 				if err := p.updateNowPlayingCard(queueItem); err != nil {
 					log.Warnf("Failed to update now-playing card: %v", err)
+					if discord.IsMissingPermissions(err) {
+						log.Warn("Stopping now-playing updates due to missing permissions")
+						return
+					}
 				}
 			case <-p.nowPlayingUpdateStop:
 				log.Debug("Stopping now-playing updates")

--- a/discord/messages.go
+++ b/discord/messages.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
-
 	"beatbot/config"
 	"beatbot/gemini"
 
@@ -15,6 +15,37 @@ import (
 	sentry "github.com/getsentry/sentry-go"
 	log "github.com/sirupsen/logrus"
 )
+
+// ErrMissingPermissions is returned when Discord responds with 403/code 50013
+type ErrMissingPermissions struct {
+	OriginalError error
+}
+
+func (e *ErrMissingPermissions) Error() string {
+	return e.OriginalError.Error()
+}
+
+func (e *ErrMissingPermissions) Unwrap() error {
+	return e.OriginalError
+}
+
+// IsMissingPermissions checks if an error is a Discord 50013 Missing Permissions error
+func IsMissingPermissions(err error) bool {
+	if err == nil {
+		return false
+	}
+	var permErr *ErrMissingPermissions
+	return errors.As(err, &permErr)
+}
+
+// classifyError wraps the error as ErrMissingPermissions if the response body contains code 50013
+func classifyError(baseErr error, responseBody []byte) error {
+	var discordErr DiscordErrorResponse
+	if json.Unmarshal(responseBody, &discordErr) == nil && discordErr.Code == 50013 {
+		return &ErrMissingPermissions{OriginalError: baseErr}
+	}
+	return baseErr
+}
 
 type FollowUpRequest struct {
 	Token           string
@@ -146,9 +177,9 @@ func SendChannelMessage(channelID, content string, embed *discordgo.MessageEmbed
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
-		err := fmt.Errorf("failed to send message: %s - %s", resp.Status, string(body))
-		log.Error(err)
-		return nil, err
+		baseErr := fmt.Errorf("failed to send message: %s - %s", resp.Status, string(body))
+		log.Error(baseErr)
+		return nil, classifyError(baseErr, body)
 	}
 
 	var message discordgo.Message
@@ -204,10 +235,29 @@ func EditChannelMessage(channelID, messageID string, content string, embed *disc
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		err := fmt.Errorf("failed to edit message: %s - %s", resp.Status, string(body))
-		log.Error(err)
-		return err
+		baseErr := fmt.Errorf("failed to edit message: %s - %s", resp.Status, string(body))
+		log.Error(baseErr)
+		return classifyError(baseErr, body)
 	}
 
 	return nil
+}
+
+// BotInviteURL returns the OAuth2 authorize URL for reinstalling the bot with updated permissions
+func BotInviteURL() string {
+	return fmt.Sprintf("https://discord.com/oauth2/authorize?client_id=%s", config.Config.Discord.AppID)
+}
+
+// SendPermissionErrorFallback sends a plain-text message explaining the bot needs to be
+// reinstalled with updated permissions. If this message also fails, it just logs the error.
+func SendPermissionErrorFallback(channelID string) {
+	msg := fmt.Sprintf(
+		"⚠️ I couldn't send the now-playing card because I'm missing permissions in this channel.\n"+
+			"A server admin needs to reinstall the bot to grant updated permissions:\n%s",
+		BotInviteURL(),
+	)
+	_, err := SendChannelMessage(channelID, msg, nil, nil)
+	if err != nil {
+		log.Warnf("Failed to send permission error fallback message: %v", err)
+	}
 }

--- a/discord/messages.go
+++ b/discord/messages.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
 	"beatbot/config"
 	"beatbot/gemini"
 


### PR DESCRIPTION
## Problem
When the bot tries to send a now-playing card and gets back a `403 Forbidden` with Discord error code `50013` (Missing Permissions), it was silently logging the error. This happens when a user hasn't reinstalled the bot after permissions were updated.

## Solution
- Added a typed `ErrMissingPermissions` error that gets classified at the HTTP layer when Discord returns code `50013`
- On permission error, sends a plain-text fallback message to the channel explaining the issue and including a reinstall link (generated from the app ID)
- Stops the now-playing periodic update loop cleanly on permission errors instead of spamming
- Skips Sentry reporting for permission errors (user error, not a bug)

## Files Changed
- `discord/messages.go` — typed error, classification logic, `BotInviteURL()`, `SendPermissionErrorFallback()`
- `controller/controller.go` — handle permission errors at call sites