### PR TITLE
fix: pass GEMINI_MODEL env var through docker-restart.sh

### DIFF
--- a/docker-restart.sh
+++ b/docker-restart.sh
@@ -45,6 +45,7 @@ docker run -d --name discord-audio-streamer \
   -e SPOTIFY_ENABLED=true \
   -e GEMINI_API_KEY=$GEMINI_API_KEY \
   -e GEMINI_ENABLED=$GEMINI_ENABLED \
+  -e GEMINI_MODEL=$GEMINI_MODEL \
   -e CLOUDFLARE_TUNNEL_URL=$CLOUDFLARE_TUNNEL_URL \
   -e SENTRY_DSN=$SENTRY_DSN \
   benminer/discord-audio-streamer:latest


### PR DESCRIPTION
## Why

The `GEMINI_MODEL` env var added in #76 wasn't being forwarded to the container via `docker run -e`, so the container always fell back to the Dockerfile's baked-in default (`gemini-2.5-flash`) regardless of what was set in `.env`. This blocked switching to a different model after Google restricted access to `gemini-2.5-flash` for new API keys.

## What Changed

Added `-e GEMINI_MODEL=$GEMINI_MODEL` to the `docker run` command in `docker-restart.sh`, matching the pattern used for all other env vars.