### PR TITLE
feat: add TTS DJ announcements with radio-style crossfade

### DIFF
--- a/.env.common
+++ b/.env.common
@@ -7,3 +7,4 @@ YOUTUBE_API_KEY=
 GEMINI_API_KEY=
 GEMINI_ENABLED=false
 GEMINI_MODEL=gemini-2.5-flash
+GEMINI_TTS_MODEL=gemini-2.5-flash-preview-tts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,7 @@ Key vars in `.env`:
 - `GEMINI_API_KEY` - Google Gemini API key (optional)
 - `GEMINI_ENABLED` - Enable AI responses (default: false)
 - `GEMINI_MODEL` - Gemini model name (default: gemini-2.5-flash)
+- `GEMINI_TTS_MODEL` - Gemini TTS model name (default: gemini-2.5-flash-preview-tts)
 - `IDLE_TIMEOUT_MINUTES` - Idle disconnect timeout (default: 20)
 - `SENTRY_DSN` - Sentry error tracking (optional)
 

--- a/audio/player.go
+++ b/audio/player.go
@@ -28,9 +28,12 @@ type Player struct {
 	fadeOutRemaining  atomic.Int32
 	mutex             sync.Mutex
 	playbackStartTime time.Time
-	playbackPosition  atomic.Int64 // microseconds
-	silenceBuffer     []int16      // Pre-allocated for pause loop
-	silenceOpus       []byte       // Pre-allocated for pause loop
+	playbackPosition  atomic.Int64                // microseconds
+	silenceBuffer     []int16                     // Pre-allocated for pause loop
+	silenceOpus       []byte                      // Pre-allocated for pause loop
+	ttsPlayback       atomic.Pointer[TTSPlayback] // pre-generated TTS to mix during crossfade
+	crossfading       atomic.Bool                 // true when crossfade is active
+	crossfadePos      int32                       // frames into the crossfade (NOT atomic — only accessed in Play loop)
 }
 
 func NewPlayer() (*Player, error) {
@@ -82,6 +85,8 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 	p.playing.Store(true)
 	p.stopping.Store(false)
 	p.paused.Store(false)
+	p.crossfading.Store(false)
+	p.crossfadePos = 0
 	// Initialize position tracking
 	p.playbackStartTime = time.Now()
 	p.playbackPosition.Store(0)
@@ -201,6 +206,25 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 		for attempts < 3 {
 			err := binary.Read(data.ffmpegOut, binary.LittleEndian, &buffer)
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				// If crossfading and TTS still has audio, play remaining TTS solo
+				if p.crossfading.Load() {
+					tts := p.ttsPlayback.Load()
+					if tts != nil && tts.Remaining() > 0 {
+						p.logger.Debug("Music ended, continuing TTS solo")
+						ttsBuf := make([]int16, 960*2)
+						for tts.ReadFrame(ttsBuf) {
+							encoded, encErr := p.encoder.Encode(ttsBuf, opusBuffer)
+							if encErr != nil {
+								break
+							}
+							if !safeSendOpus(voiceChannel, opusBuffer[:encoded]) {
+								break
+							}
+						}
+						p.crossfading.Store(false)
+						p.ttsPlayback.Store(nil)
+					}
+				}
 				p.logger.Trace("Reached end of audio stream")
 				span.Status = sentry.SpanStatusOK
 				p.Notifications <- PlaybackNotification{
@@ -249,6 +273,40 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 			}
 		}
 
+		// Crossfade: fade out music and mix in TTS audio
+		if p.crossfading.Load() {
+			tts := p.ttsPlayback.Load()
+			if tts != nil {
+				// Slow fade-out of music over ~250 frames (5 seconds)
+				const crossfadeDuration int32 = 250
+				p.crossfadePos++
+				t := 1.0 - float64(p.crossfadePos)/float64(crossfadeDuration)
+				if t < 0 {
+					t = 0
+				}
+				musicFade := t * t // quadratic fade
+
+				// Apply music fade
+				for i := range buffer {
+					buffer[i] = int16(float64(buffer[i]) * musicFade)
+				}
+
+				// Mix in TTS audio
+				ttsBuf := make([]int16, 960*2)
+				if tts.ReadFrame(ttsBuf) || tts.Position > 0 {
+					for i := range buffer {
+						mixed := int32(buffer[i]) + int32(ttsBuf[i])
+						if mixed > 32767 {
+							mixed = 32767
+						} else if mixed < -32768 {
+							mixed = -32768
+						}
+						buffer[i] = int16(mixed)
+					}
+				}
+			}
+		}
+
 		encoded, err := p.encoder.Encode(buffer, opusBuffer)
 		if err != nil {
 			p.logger.Warnf("Error encoding to opus: %v", err)
@@ -266,6 +324,19 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 		if !p.paused.Load() && !p.stopping.Load() {
 			currentPos := p.playbackPosition.Load() + 20000 // 20ms in microseconds
 			p.playbackPosition.Store(currentPos)
+		}
+
+		// Check if we should start crossfading (TTS ready + approaching end of song)
+		if !p.crossfading.Load() && data.Duration > 0 {
+			tts := p.ttsPlayback.Load()
+			if tts != nil {
+				remaining := data.Duration - p.GetPosition()
+				if remaining <= 5*time.Second && remaining > 0 {
+					p.crossfading.Store(true)
+					p.crossfadePos = 0
+					p.logger.Debug("Starting TTS crossfade")
+				}
+			}
 		}
 
 		if !safeSendOpus(voiceChannel, opusBuffer[:encoded]) {
@@ -291,6 +362,15 @@ func safeSendOpus(vc *discordgo.VoiceConnection, data []byte) (sent bool) {
 	}()
 	vc.OpusSend <- data
 	return true
+}
+
+func (p *Player) SetTTSPlayback(tts *TTSPlayback) {
+	p.ttsPlayback.Store(tts)
+}
+
+func (p *Player) ClearTTSPlayback() {
+	p.ttsPlayback.Store(nil)
+	p.crossfading.Store(false)
 }
 
 func (p *Player) Pause(ctx context.Context) {

--- a/audio/tts.go
+++ b/audio/tts.go
@@ -1,0 +1,72 @@
+package audio
+
+// TTS audio conversion and playback utilities.
+// Gemini TTS returns raw 16-bit LE PCM at 24kHz mono; Discord voice expects
+// 48kHz stereo int16 frames matching the Opus encoder used by Player.
+
+import (
+	"bytes"
+	"encoding/binary"
+	"time"
+)
+
+const ttsFrameSamples = 960 * 2 // 20ms frame at 48kHz stereo
+
+// ConvertTTSToDiscord upsamples 24kHz mono PCM to 48kHz stereo by
+// duplicating each sample twice for rate doubling and twice more for
+// stereo, producing S, S, S, S per input sample S.
+func ConvertTTSToDiscord(pcm24kMono []byte) []int16 {
+	reader := bytes.NewReader(pcm24kMono)
+	samples := make([]int16, 0, (len(pcm24kMono)/2)*4)
+
+	for {
+		var sample int16
+		if err := binary.Read(reader, binary.LittleEndian, &sample); err != nil {
+			break
+		}
+		samples = append(samples, sample, sample, sample, sample)
+	}
+
+	return samples
+}
+
+type TTSPlayback struct {
+	Samples  []int16 // 48kHz stereo, pre-converted
+	Position int     // current read position (in samples, not frames)
+}
+
+// ReadFrame reads the next 20ms frame (960*2 samples) into buf, advancing
+// Position. Returns false once the frame could not be fully filled, in
+// which case any remaining space in buf is zero-filled.
+func (t *TTSPlayback) ReadFrame(buf []int16) bool {
+	remaining := len(t.Samples) - t.Position
+	if remaining <= 0 {
+		for i := range buf {
+			buf[i] = 0
+		}
+		return false
+	}
+
+	if remaining < ttsFrameSamples {
+		n := copy(buf, t.Samples[t.Position:])
+		for i := n; i < len(buf); i++ {
+			buf[i] = 0
+		}
+		t.Position += remaining
+		return false
+	}
+
+	copy(buf, t.Samples[t.Position:t.Position+ttsFrameSamples])
+	t.Position += ttsFrameSamples
+	return true
+}
+
+// Remaining returns how much TTS audio is left to play.
+func (t *TTSPlayback) Remaining() time.Duration {
+	remainingSamples := len(t.Samples) - t.Position
+	if remainingSamples < 0 {
+		remainingSamples = 0
+	}
+	monoSamples := float64(remainingSamples) / 2
+	return time.Duration(monoSamples / 48000 * float64(time.Second))
+}

--- a/commands.json
+++ b/commands.json
@@ -193,5 +193,31 @@
         "max_value": 25
       }
     ]
+  },
+  {
+    "name": "announce",
+    "type": 1,
+    "description": "Toggle DJ voice announcements between songs",
+    "options": [
+      {
+        "name": "voice",
+        "description": "Set the DJ voice (e.g. Kore, Puck, Charon)",
+        "type": 3,
+        "required": false
+      }
+    ]
+  },
+  {
+    "name": "voice-demo",
+    "type": 1,
+    "description": "Preview the DJ voice with a short quip",
+    "options": [
+      {
+        "name": "voice",
+        "description": "Voice to preview (uses current voice if omitted)",
+        "type": 3,
+        "required": false
+      }
+    ]
   }
 ]

--- a/config/config.go
+++ b/config/config.go
@@ -30,9 +30,10 @@ type YoutubeConfig struct {
 }
 
 type GeminiConfig struct {
-	Enabled bool
-	APIKey  string
-	Model   string
+	Enabled  bool
+	APIKey   string
+	Model    string
+	TTSModel string
 }
 
 type SpotifyConfig struct {
@@ -80,9 +81,10 @@ func NewConfig() {
 			PlaylistLimit: getYouTubePlaylistLimit(),
 		},
 		Gemini: GeminiConfig{
-			Enabled: os.Getenv("GEMINI_ENABLED") == "true",
-			APIKey:  os.Getenv("GEMINI_API_KEY"),
-			Model:   getGeminiModel(),
+			Enabled:  os.Getenv("GEMINI_ENABLED") == "true",
+			APIKey:   os.Getenv("GEMINI_API_KEY"),
+			Model:    getGeminiModel(),
+			TTSModel: getGeminiTTSModel(),
 		},
 		Spotify: SpotifyConfig{
 			ClientID:      os.Getenv("SPOTIFY_CLIENT_ID"),
@@ -161,6 +163,14 @@ func getGeminiModel() string {
 	model := os.Getenv("GEMINI_MODEL")
 	if model == "" {
 		return "gemini-2.5-flash"
+	}
+	return model
+}
+
+func getGeminiTTSModel() string {
+	model := os.Getenv("GEMINI_TTS_MODEL")
+	if model == "" {
+		return "gemini-2.5-flash-preview-tts"
 	}
 	return model
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -130,6 +130,10 @@ type GuildPlayer struct {
 	LoopEnabled      bool
 	loopMutex        sync.RWMutex
 
+	// Voice DJ announcement settings (persisted via guild_settings)
+	AnnounceEnabled bool
+	AnnounceVoice   string
+
 	// Now-playing card tracking
 	NowPlayingMessageID   *string
 	NowPlayingChannelID   *string

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -299,6 +299,16 @@ func (c *Controller) GetPlayer(guildID string) *GuildPlayer {
 		playerCancel:         playerCancel,
 	}
 
+	// Load announce settings from DB
+	if val, _ := c.db.GetGuildSetting(guildID, "announce_enabled"); val == "true" {
+		session.AnnounceEnabled = true
+	}
+	if val, _ := c.db.GetGuildSetting(guildID, "announce_voice"); val != "" {
+		session.AnnounceVoice = val
+	} else {
+		session.AnnounceVoice = "Kore"
+	}
+
 	session.listenForQueueEvents()
 	session.listenForPlaybackEvents()
 	session.listenForLoadEvents()
@@ -1096,6 +1106,9 @@ func (p *GuildPlayer) listenForPlaybackEvents() {
 					p.stopNowPlayingUpdates()
 					p.clearNowPlayingCard()
 
+					// Clear any pre-generated TTS so it doesn't carry over
+					p.Player.ClearTTSPlayback()
+
 					// Loop current song if enabled
 					p.currentItemMutex.RLock()
 					currentItemForLoop := p.CurrentItem
@@ -1158,6 +1171,9 @@ func (p *GuildPlayer) listenForPlaybackEvents() {
 
 						// Send now-playing card
 						go p.sendNowPlayingCard(queueItem)
+
+						// Pre-generate TTS for the transition to the next song
+						go p.preGenerateTTS(queueItem)
 
 						// Record in song history for radio mode
 						p.SongHistory.Add(SongHistoryEntry{
@@ -1829,6 +1845,54 @@ func (p *GuildPlayer) sendRecoveryMessage(message string) {
 			log.Errorf("Failed to send recovery message to channel %s: %v", textCh, err)
 		}
 	}
+}
+
+// preGenerateTTS generates TTS audio for the transition between the current
+// song and the next song in queue, then sets it on the player for crossfade.
+// Runs as a goroutine - errors are logged but never propagated.
+func (p *GuildPlayer) preGenerateTTS(currentItem *GuildQueueItem) {
+	if !p.AnnounceEnabled || !config.Config.Gemini.Enabled {
+		return
+	}
+
+	nextItem := p.GetNext()
+	if nextItem == nil {
+		return
+	}
+
+	currentSong := currentItem.Video.Title
+	nextSong := nextItem.Video.Title
+
+	// Build recent history titles
+	recentEntries := p.SongHistory.GetRecent(5)
+	recentHistory := make([]string, len(recentEntries))
+	for i, entry := range recentEntries {
+		recentHistory[i] = entry.Title
+	}
+
+	isRadioPick := currentItem.IsRadioPick
+
+	ctx := p.playerCtx
+	span := sentry.StartSpan(ctx, "tts.pre_generate")
+	defer span.Finish()
+	ctx = span.Context()
+
+	script := gemini.GenerateDJTransitionScript(ctx, currentSong, nextSong, recentHistory, isRadioPick)
+	if script == "" {
+		return
+	}
+
+	audioBytes, err := gemini.GenerateTTSAudio(ctx, script, p.AnnounceVoice, "")
+	if err != nil {
+		log.Errorf("TTS pre-generation failed: %v", err)
+		return
+	}
+
+	samples := audio.ConvertTTSToDiscord(audioBytes)
+	tts := &audio.TTSPlayback{Samples: samples}
+	p.Player.SetTTSPlayback(tts)
+
+	log.Infof("TTS pre-generated for transition: %s → %s", currentSong, nextSong)
 }
 
 // sendNowPlayingCard creates and sends a now-playing embed

--- a/database/database.go
+++ b/database/database.go
@@ -125,6 +125,12 @@ func (d *Database) migrate() error {
 		// inserted even under concurrent load. INSERT OR IGNORE in AddFavorite
 		// relies on this constraint for idempotency.
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_user_favorites_unique ON user_favorites(user_id, guild_id, video_id)`,
+		`CREATE TABLE IF NOT EXISTS guild_settings (
+			guild_id TEXT NOT NULL,
+			key TEXT NOT NULL,
+			value TEXT NOT NULL,
+			PRIMARY KEY (guild_id, key)
+		)`,
 	}
 
 	for _, m := range migrations {
@@ -470,4 +476,33 @@ func (d *Database) RemoveFavoriteByIndex(userID, guildID string, index int) (str
 	}
 
 	return title, tx.Commit()
+}
+
+// GetGuildSetting returns the value for a per-guild setting, or "" if not found.
+func (d *Database) GetGuildSetting(guildID, key string) (string, error) {
+	var value string
+	err := d.db.QueryRow(
+		`SELECT value FROM guild_settings WHERE guild_id = ? AND key = ?`,
+		guildID, key,
+	).Scan(&value)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to get guild setting %s/%s: %w", guildID, key, err)
+	}
+	return value, nil
+}
+
+// SetGuildSetting upserts a per-guild setting.
+func (d *Database) SetGuildSetting(guildID, key, value string) error {
+	_, err := d.db.Exec(
+		`INSERT INTO guild_settings (guild_id, key, value) VALUES (?, ?, ?)
+		 ON CONFLICT(guild_id, key) DO UPDATE SET value = excluded.value`,
+		guildID, key, value,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to set guild setting %s/%s: %w", guildID, key, err)
+	}
+	return nil
 }

--- a/docker-restart.sh
+++ b/docker-restart.sh
@@ -46,6 +46,7 @@ docker run -d --name discord-audio-streamer \
   -e GEMINI_API_KEY=$GEMINI_API_KEY \
   -e GEMINI_ENABLED=$GEMINI_ENABLED \
   -e GEMINI_MODEL=$GEMINI_MODEL \
+  -e GEMINI_TTS_MODEL=$GEMINI_TTS_MODEL \
   -e CLOUDFLARE_TUNNEL_URL=$CLOUDFLARE_TUNNEL_URL \
   -e SENTRY_DSN=$SENTRY_DSN \
   benminer/discord-audio-streamer:latest

--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -16,6 +16,15 @@ import (
 // Creating a new HTTP client + TLS session on every call was wasteful.
 var defaultClient *genai.Client
 
+// AvailableVoices lists all Gemini TTS voice presets available for DJ announcements.
+var AvailableVoices = []string{
+	"Zephyr", "Puck", "Charon", "Kore", "Fenrir", "Leda", "Orus", "Aoede",
+	"Callirrhoe", "Autonoe", "Enceladus", "Iapetus", "Umbriel", "Algieba",
+	"Despina", "Erinome", "Algenib", "Rasalgethi", "Laomedeia", "Achernar",
+	"Alnilam", "Schedar", "Gacrux", "Pulcherrima", "Achird", "Zubenelgenubi",
+	"Vindemiatrix", "Sadachbia", "Sadaltager", "Sulafat",
+}
+
 // Init initializes the shared Gemini client. Must be called once at startup
 // (after config is loaded) before any Gemini functions are used. Safe to call
 // when Gemini is disabled — it becomes a no-op.
@@ -327,4 +336,119 @@ Now write your commentary:`, currentSong, historyStr, radioStr))
 	}).Debug("Generated now playing commentary")
 
 	return commentary
+}
+
+// GenerateDJTransitionScript generates a short spoken-word transition line that a
+// DJ would say over the fade-out of the current song before the next one starts.
+// The result is intended to be fed into TTS, so it avoids markdown and formatting.
+func GenerateDJTransitionScript(ctx context.Context, currentSong, nextSong string, recentHistory []string, isRadioPick bool) string {
+	if !config.Config.Gemini.Enabled || defaultClient == nil {
+		return ""
+	}
+
+	span := sentry.StartSpan(ctx, "gemini.dj_transition_script")
+	span.Description = "Generate DJ transition script for TTS"
+	span.SetTag("model", config.Config.Gemini.Model)
+	defer span.Finish()
+
+	var historyStr string
+	if len(recentHistory) > 0 {
+		historyStr = "Recent songs played (most recent first):\n"
+		for i, song := range recentHistory {
+			historyStr += fmt.Sprintf("%d. %s\n", i+1, song)
+		}
+	} else {
+		historyStr = "This is the first song in the session."
+	}
+
+	radioStr := ""
+	if isRadioPick {
+		radioStr = "This next song was auto-queued by radio mode based on the listening pattern."
+	}
+
+	instructions := buildPrompt(fmt.Sprintf(`You are about to talk over the fade-out of the current song. Write ONE sentence that transitions from the current song to the next one.
+
+Current song: %s
+Next up: %s
+
+%s
+
+%s
+
+Rules:
+- ONE sentence ONLY
+- No markdown. No bold. No asterisks
+- Natural spoken cadence. This will be read aloud by text-to-speech
+- Keep it SHORT - 5-10 words ideal, 15 words max
+- Think like a radio DJ talking over the tail of a song
+
+Example good: "Fading out the Weeknd, rolling into some Daft Punk next."
+Example bad: "**The Weeknd's** track was great! Now let me introduce you to **Daft Punk** with their amazing hit!"
+
+Now write your transition:`, currentSong, nextSong, historyStr, radioStr))
+
+	response := generateResponse(ctx, instructions)
+	if response == "" {
+		span.Status = sentry.SpanStatusInternalError
+		return ""
+	}
+
+	span.Status = sentry.SpanStatusOK
+	return strings.TrimSpace(response)
+}
+
+// GenerateTTSAudio synthesizes speech from a script using Gemini's TTS model.
+// Returns raw PCM audio data (16-bit 24kHz mono). The caller is responsible for
+// encoding or resampling before sending to Discord.
+func GenerateTTSAudio(ctx context.Context, script, voice, model string) ([]byte, error) {
+	if defaultClient == nil {
+		return nil, fmt.Errorf("gemini client not initialized")
+	}
+
+	if model == "" {
+		model = config.Config.Gemini.TTSModel
+	}
+	if voice == "" {
+		voice = "Kore"
+	}
+
+	span := sentry.StartSpan(ctx, "gemini.tts")
+	span.Description = "Generate TTS audio"
+	span.SetTag("model", model)
+	span.SetTag("voice", voice)
+	defer span.Finish()
+
+	content := []*genai.Content{{Parts: []*genai.Part{{Text: script}}}}
+	resp, err := defaultClient.Models.GenerateContent(ctx, model, content, &genai.GenerateContentConfig{
+		ResponseModalities: []string{"AUDIO"},
+		SpeechConfig: &genai.SpeechConfig{
+			VoiceConfig: &genai.VoiceConfig{
+				PrebuiltVoiceConfig: &genai.PrebuiltVoiceConfig{
+					VoiceName: voice,
+				},
+			},
+		},
+	})
+	if err != nil {
+		log.WithFields(log.Fields{
+			"module": "gemini",
+			"model":  model,
+			"voice":  voice,
+		}).Errorf("TTS generation failed: %v", err)
+		sentry.CaptureException(err)
+		span.Status = sentry.SpanStatusInternalError
+		return nil, fmt.Errorf("TTS generation failed: %w", err)
+	}
+
+	if len(resp.Candidates) == 0 || resp.Candidates[0].Content == nil ||
+		len(resp.Candidates[0].Content.Parts) == 0 || resp.Candidates[0].Content.Parts[0].InlineData == nil {
+		err := fmt.Errorf("TTS response contained no audio data")
+		log.WithField("module", "gemini").Error(err)
+		sentry.CaptureException(err)
+		span.Status = sentry.SpanStatusInternalError
+		return nil, err
+	}
+
+	span.Status = sentry.SpanStatusOK
+	return resp.Candidates[0].Content.Parts[0].InlineData.Data, nil
 }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -265,6 +265,12 @@ func (manager *Manager) HandleInteraction(interaction *Interaction) (response Re
 		return manager.handleFavorites(interaction)
 	case "unfavorite":
 		return manager.handleUnfavorite(interaction)
+	case "announce":
+		return manager.handleAnnounce(ctx, interaction)
+	case "voice-demo":
+		finishTransaction = false
+		go manager.handleVoiceDemo(ctx, transaction, interaction)
+		return Response{Type: 5}
 	// case "purge":
 	// 	return manager.handlePurge(interaction)
 	default:

--- a/handlers/playback.go
+++ b/handlers/playback.go
@@ -4,9 +4,20 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
+	sentry "github.com/getsentry/sentry-go"
+	log "github.com/sirupsen/logrus"
+
+	"beatbot/audio"
+	"beatbot/discord"
+	"beatbot/gemini"
 	"beatbot/helpers"
+	"beatbot/sentryhelper"
+
+	"github.com/bwmarrin/discordgo"
+	"gopkg.in/hraban/opus.v2"
 )
 
 func (manager *Manager) handleVolume(ctx context.Context, interaction *Interaction) Response {
@@ -158,4 +169,219 @@ func (manager *Manager) handleRadio(ctx context.Context, interaction *Interactio
 			Content: msg + hint,
 		},
 	}
+}
+
+func (manager *Manager) handleAnnounce(ctx context.Context, interaction *Interaction) Response {
+	guildID := interaction.GuildID
+	player := manager.Controller.GetPlayer(guildID)
+
+	// Check if "voice" option was provided
+	var voiceOption string
+	for _, opt := range interaction.Data.Options {
+		if opt.Name == "voice" {
+			voiceOption = opt.Value
+			break
+		}
+	}
+
+	if voiceOption != "" {
+		// Validate voice name against gemini.AvailableVoices (case-insensitive)
+		var matchedVoice string
+		for _, v := range gemini.AvailableVoices {
+			if strings.EqualFold(v, voiceOption) {
+				matchedVoice = v
+				break
+			}
+		}
+
+		if matchedVoice == "" {
+			voiceList := strings.Join(gemini.AvailableVoices, ", ")
+			return Response{
+				Type: 4,
+				Data: ResponseData{
+					Content: fmt.Sprintf("Unknown voice **%s**. Available voices: %s", voiceOption, voiceList),
+					Flags:   64,
+				},
+			}
+		}
+
+		// Save to DB and update in-memory state
+		if player.DB != nil {
+			if err := player.DB.SetGuildSetting(guildID, "announce_voice", matchedVoice); err != nil {
+				log.Errorf("Failed to save announce voice: %v", err)
+			}
+		}
+		player.AnnounceVoice = matchedVoice
+
+		hint := manager.Hints.ShowIfApplicable(guildID)
+
+		return Response{
+			Type: 4,
+			Data: ResponseData{
+				Content: fmt.Sprintf("🎙️ DJ voice set to **%s**", matchedVoice) + hint,
+			},
+		}
+	}
+
+	// Toggle announce enabled
+	player.AnnounceEnabled = !player.AnnounceEnabled
+
+	enabledStr := "false"
+	if player.AnnounceEnabled {
+		enabledStr = "true"
+	}
+
+	if player.DB != nil {
+		if err := player.DB.SetGuildSetting(guildID, "announce_enabled", enabledStr); err != nil {
+			log.Errorf("Failed to save announce setting: %v", err)
+		}
+	}
+
+	// Generate DJ response with a tight deadline so we never blow Discord's 3s interaction limit
+	djCtx, djCancel := context.WithTimeout(ctx, 1500*time.Millisecond)
+	defer djCancel()
+	djResponse := helpers.GenerateDJResponse(djCtx, "announce", player.AnnounceEnabled)
+	hint := manager.Hints.ShowIfApplicable(guildID)
+
+	var msg string
+	if player.AnnounceEnabled {
+		msg = "🎙️ Voice announcements **enabled** — " + djResponse
+	} else {
+		msg = "🔇 Voice announcements **disabled** — " + djResponse
+	}
+
+	return Response{
+		Type: 4,
+		Data: ResponseData{
+			Content: msg + hint,
+		},
+	}
+}
+
+func (manager *Manager) handleVoiceDemo(ctx context.Context, transaction *sentry.Span, interaction *Interaction) {
+	defer func() {
+		if err := recover(); err != nil {
+			sentryhelper.CaptureException(ctx, fmt.Errorf("panic in handleVoiceDemo: %v", err))
+			transaction.Status = sentry.SpanStatusInternalError
+		}
+		transaction.Finish()
+	}()
+
+	guildID := interaction.GuildID
+
+	// Check if user is in a voice channel
+	voiceState, err := discord.GetMemberVoiceState(&interaction.Member.User.ID, &interaction.GuildID)
+	if err != nil {
+		log.Errorf("Error getting voice state: %v", err)
+		sentryhelper.CaptureException(ctx, err)
+		manager.SendError(interaction, "Error getting voice state: "+err.Error(), true)
+		return
+	}
+	if voiceState == nil {
+		manager.SendRequest(interaction, "Join a voice channel first!", true)
+		return
+	}
+
+	player := manager.Controller.GetPlayer(guildID)
+
+	// Join voice if needed
+	if player.ShouldJoinVoice(voiceState.ChannelID) {
+		if err := player.JoinVoiceChannel(interaction.Member.User.ID); err != nil {
+			sentryhelper.CaptureException(ctx, err)
+			manager.SendError(interaction, "Error joining voice channel: "+err.Error(), true)
+			return
+		}
+	}
+
+	// Get voice from option, or from guild settings, or default to "Kore"
+	var voice string
+	for _, opt := range interaction.Data.Options {
+		if opt.Name == "voice" {
+			voice = opt.Value
+			break
+		}
+	}
+	if voice == "" {
+		voice = player.AnnounceVoice
+	}
+	if voice == "" && player.DB != nil {
+		if v, _ := player.DB.GetGuildSetting(guildID, "announce_voice"); v != "" {
+			voice = v
+		}
+	}
+	if voice == "" {
+		voice = "Kore"
+	}
+
+	// Generate a short demo script via Gemini
+	script := gemini.GenerateRaw(ctx, "Say something cool and brief as a radio DJ in one sentence. No markdown.")
+	if script == "" {
+		script = "Testing, testing. Your DJ is live and ready to drop some beats."
+	}
+
+	// Generate TTS audio
+	audioBytes, err := gemini.GenerateTTSAudio(ctx, script, voice, "")
+	if err != nil {
+		log.Errorf("TTS generation failed: %v", err)
+		sentryhelper.CaptureException(ctx, err)
+		manager.SendError(interaction, "TTS generation failed: "+err.Error(), true)
+		return
+	}
+
+	// Convert to Discord format (48kHz stereo)
+	samples := audio.ConvertTTSToDiscord(audioBytes)
+	ttsPlayback := &audio.TTSPlayback{Samples: samples}
+
+	// Get the voice connection
+	player.VoiceChannelMutex.RLock()
+	vc := player.VoiceConnection
+	player.VoiceChannelMutex.RUnlock()
+
+	if vc == nil {
+		manager.SendError(interaction, "Not connected to a voice channel", true)
+		return
+	}
+
+	// Create a temporary Opus encoder (matches player.go settings)
+	encoder, err := opus.NewEncoder(48000, 2, opus.AppAudio)
+	if err != nil {
+		log.Errorf("Error creating opus encoder: %v", err)
+		sentryhelper.CaptureException(ctx, err)
+		manager.SendError(interaction, "Error creating audio encoder", true)
+		return
+	}
+
+	// Play TTS frames through the voice connection
+	vc.Speaking(true)
+
+	frameBuf := make([]int16, 960*2)
+	opusBuf := make([]byte, 960*4)
+
+	for ttsPlayback.ReadFrame(frameBuf) {
+		encoded, encErr := encoder.Encode(frameBuf, opusBuf)
+		if encErr != nil {
+			log.Warnf("Error encoding TTS frame: %v", encErr)
+			break
+		}
+		if !trySendOpus(vc, opusBuf[:encoded]) {
+			break
+		}
+	}
+
+	vc.Speaking(false)
+
+	// Send followup message with the voice name and the script text
+	manager.SendRequest(interaction, fmt.Sprintf("🎙️ Voice preview (**%s**): *%s*", voice, script), false)
+}
+
+// trySendOpus sends opus data to the voice connection, recovering from panics
+// caused by sending on a closed channel (voice disconnected mid-playback).
+func trySendOpus(vc *discordgo.VoiceConnection, data []byte) (sent bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			sent = false
+		}
+	}()
+	vc.OpusSend <- data
+	return true
 }

--- a/helpers/gemini.go
+++ b/helpers/gemini.go
@@ -21,6 +21,7 @@ var DJFallbacks = map[string]string{
 	"volume":      "Volume adjusted.",
 	"radio":       "Radio mode toggled.",
 	"loop":        "Loop mode toggled.",
+	"announce":    "DJ announcements toggled.",
 	"history":     "Here's what we've been vibing to.",
 	"leaderboard": "Top tracks incoming.",
 	"favorites":   "Your saved tracks.",
@@ -138,6 +139,17 @@ func buildDJPrompt(command string, args []interface{}) string {
 			action = "enabled"
 		}
 		return fmt.Sprintf("Write a brief DJ response to loop mode being %s. Keep it brief. One sentence.", action)
+
+	case "announce":
+		enabled := false
+		if len(args) > 0 {
+			enabled = args[0].(bool)
+		}
+		action := "disabled"
+		if enabled {
+			action = "enabled"
+		}
+		return fmt.Sprintf("Write a brief DJ response to voice announcements being %s. Keep it brief. One sentence.", action)
 
 	case "history":
 		return "Write a brief DJ response showing the recent history. Keep it casual. One sentence."


### PR DESCRIPTION
## Why

The bot has a sassy DJ personality that generates text commentary, but users can't hear it. This adds audible DJ announcements between songs using Gemini TTS, with a radio-style crossfade where the DJ talks over the fading tail of the outgoing song.

## What Changed

- **Gemini TTS integration**: `GenerateDJTransitionScript` generates short spoken-word DJ transitions, `GenerateTTSAudio` synthesizes speech via `gemini-2.5-flash-preview-tts` with 30 configurable voices
- **Audio crossfade**: Player detects ~5s remaining in a song, slow-fades the music while mixing in pre-generated TTS audio, then continues TTS solo after music ends
- **Pre-generation**: TTS is generated async while the current song plays, so there's zero latency when the crossfade triggers
- **`/announce` command**: Toggles TTS announcements per server, configures voice (persisted in new `guild_settings` SQLite table)
- **`/voice-demo` command**: Previews any TTS voice with a short quip through the voice channel
- **Config**: `GEMINI_TTS_MODEL` env var for the TTS model name

## Test plan

- [ ] `/announce` toggles on/off, persists across restarts
- [ ] `/announce voice Puck` changes voice, validates against known list
- [ ] `/voice-demo` plays a quip through voice channel
- [ ] Play two songs with announce enabled: DJ voice crossfades over tail of first song
- [ ] Disable Gemini: songs transition normally without TTS
- [ ] Empty queue: no announcement attempted