### PR TITLE
fix: replace naive TTS conversion with FFmpeg resampling

### DIFF
--- a/audio/tts.go
+++ b/audio/tts.go
@@ -7,27 +7,76 @@ package audio
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"os/exec"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const ttsFrameSamples = 960 * 2 // 20ms frame at 48kHz stereo
 
-// ConvertTTSToDiscord upsamples 24kHz mono PCM to 48kHz stereo by
-// duplicating each sample twice for rate doubling and twice more for
-// stereo, producing S, S, S, S per input sample S.
-func ConvertTTSToDiscord(pcm24kMono []byte) []int16 {
-	reader := bytes.NewReader(pcm24kMono)
-	samples := make([]int16, 0, (len(pcm24kMono)/2)*4)
-
-	for {
-		var sample int16
-		if err := binary.Read(reader, binary.LittleEndian, &sample); err != nil {
-			break
-		}
-		samples = append(samples, sample, sample, sample, sample)
+// ConvertTTSToDiscord resamples TTS audio to 48kHz stereo PCM using FFmpeg.
+// Accepts raw 24kHz mono PCM (the default Gemini TTS output) or WAV.
+// Falls back to raw PCM input flags if auto-detection fails.
+func ConvertTTSToDiscord(ttsAudio []byte) ([]int16, error) {
+	if len(ttsAudio) == 0 {
+		return nil, fmt.Errorf("empty TTS audio data")
 	}
 
-	return samples
+	isWAV := len(ttsAudio) >= 4 && string(ttsAudio[:4]) == "RIFF"
+
+	var cmd *exec.Cmd
+	if isWAV {
+		log.Debug("TTS audio detected as WAV, using auto-detection")
+		cmd = exec.Command("ffmpeg",
+			"-i", "pipe:0",
+			"-f", "s16le",
+			"-ar", "48000",
+			"-ac", "2",
+			"-loglevel", "error",
+			"pipe:1")
+	} else {
+		log.Debug("TTS audio detected as raw PCM, using explicit format flags")
+		cmd = exec.Command("ffmpeg",
+			"-f", "s16le",
+			"-ar", "24000",
+			"-ac", "1",
+			"-i", "pipe:0",
+			"-f", "s16le",
+			"-ar", "48000",
+			"-ac", "2",
+			"-af", "aresample=48000",
+			"-loglevel", "error",
+			"pipe:1")
+	}
+
+	cmd.Stdin = bytes.NewReader(ttsAudio)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("FFmpeg TTS conversion failed: %w (stderr: %s)", err, stderr.String())
+	}
+
+	if len(output) == 0 {
+		return nil, fmt.Errorf("FFmpeg produced empty output")
+	}
+
+	samples := make([]int16, len(output)/2)
+	if err := binary.Read(bytes.NewReader(output), binary.LittleEndian, &samples); err != nil {
+		return nil, fmt.Errorf("failed to read FFmpeg output as int16: %w", err)
+	}
+
+	log.WithFields(log.Fields{
+		"input_bytes":    len(ttsAudio),
+		"output_samples": len(samples),
+		"duration_ms":    len(samples) / 2 / 48,
+		"is_wav":         isWAV,
+	}).Debug("TTS audio converted to Discord format")
+
+	return samples, nil
 }
 
 type TTSPlayback struct {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1888,7 +1888,11 @@ func (p *GuildPlayer) preGenerateTTS(currentItem *GuildQueueItem) {
 		return
 	}
 
-	samples := audio.ConvertTTSToDiscord(audioBytes)
+	samples, convErr := audio.ConvertTTSToDiscord(audioBytes)
+	if convErr != nil {
+		log.Errorf("TTS audio conversion failed: %v", convErr)
+		return
+	}
 	tts := &audio.TTSPlayback{Samples: samples}
 	p.Player.SetTTSPlayback(tts)
 

--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -449,6 +449,13 @@ func GenerateTTSAudio(ctx context.Context, script, voice, model string) ([]byte,
 		return nil, err
 	}
 
+	inlineData := resp.Candidates[0].Content.Parts[0].InlineData
+	log.WithFields(log.Fields{
+		"module":    "gemini",
+		"mime_type": inlineData.MIMEType,
+		"data_size": len(inlineData.Data),
+	}).Debug("TTS audio received from Gemini")
+
 	span.Status = sentry.SpanStatusOK
-	return resp.Candidates[0].Content.Parts[0].InlineData.Data, nil
+	return inlineData.Data, nil
 }

--- a/handlers/playback.go
+++ b/handlers/playback.go
@@ -328,8 +328,14 @@ func (manager *Manager) handleVoiceDemo(ctx context.Context, transaction *sentry
 		return
 	}
 
-	// Convert to Discord format (48kHz stereo)
-	samples := audio.ConvertTTSToDiscord(audioBytes)
+	// Convert to Discord format (48kHz stereo) via FFmpeg
+	samples, convErr := audio.ConvertTTSToDiscord(audioBytes)
+	if convErr != nil {
+		log.Errorf("TTS audio conversion failed: %v", convErr)
+		sentryhelper.CaptureException(ctx, convErr)
+		manager.SendError(interaction, "Audio conversion failed: "+convErr.Error(), true)
+		return
+	}
 	ttsPlayback := &audio.TTSPlayback{Samples: samples}
 
 	// Get the voice connection
@@ -350,9 +356,12 @@ func (manager *Manager) handleVoiceDemo(ctx context.Context, transaction *sentry
 		manager.SendError(interaction, "Error creating audio encoder", true)
 		return
 	}
+	encoder.SetComplexity(10)
+	encoder.SetBitrateToMax()
 
 	// Play TTS frames through the voice connection
 	vc.Speaking(true)
+	time.Sleep(50 * time.Millisecond)
 
 	frameBuf := make([]int16, 960*2)
 	opusBuf := make([]byte, 960*4)


### PR DESCRIPTION
## Why

TTS audio from `/voice-demo` was choppy, distorted, and unintelligible. The `ConvertTTSToDiscord` function used naive sample duplication (zero-order hold) for 24kHz→48kHz upsampling, which produces aliasing artifacts that interact badly with Opus encoding.

## What Changed

- Replaced sample-duplication conversion with FFmpeg-based resampling (matching the main audio pipeline's approach in `loader.go`), with auto-detection for WAV vs raw PCM input
- Added MIMEType and data size logging on Gemini TTS responses for format diagnostics
- Added 50ms `Speaking(true)` warm-up delay in the voice-demo handler (matching `player.go`)
- Set Opus encoder complexity and bitrate to max in voice-demo handler (matching `player.go`)