### PR TITLE
fix: TTS volume boost, blocking ticker pacing, and /voices command

### DIFF
--- a/audio/player.go
+++ b/audio/player.go
@@ -310,11 +310,18 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 					buffer[i] = int16(float64(buffer[i]) * musicFade)
 				}
 
-				// Mix in TTS audio
+				// Mix in TTS audio with 2x gain boost so it cuts through
+				// even when the music hasn't fully faded yet.
 				ttsBuf := make([]int16, 960*2)
 				if tts.ReadFrame(ttsBuf) || tts.Position > 0 {
 					for i := range buffer {
-						mixed := int32(buffer[i]) + int32(ttsBuf[i])
+						boosted := int32(float64(ttsBuf[i]) * 2.0)
+						if boosted > 32767 {
+							boosted = 32767
+						} else if boosted < -32768 {
+							boosted = -32768
+						}
+						mixed := int32(buffer[i]) + boosted
 						if mixed > 32767 {
 							mixed = 32767
 						} else if mixed < -32768 {

--- a/commands.json
+++ b/commands.json
@@ -219,5 +219,10 @@
         "required": false
       }
     ]
+  },
+  {
+    "name": "voices",
+    "type": 1,
+    "description": "List available TTS voices for DJ announcements"
   }
 ]

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -271,6 +271,8 @@ func (manager *Manager) HandleInteraction(interaction *Interaction) (response Re
 		finishTransaction = false
 		go manager.handleVoiceDemo(ctx, transaction, interaction)
 		return Response{Type: 5}
+	case "voices":
+		return manager.handleVoices(interaction)
 	// case "purge":
 	// 	return manager.handlePurge(interaction)
 	default:

--- a/handlers/playback.go
+++ b/handlers/playback.go
@@ -381,11 +381,7 @@ func (manager *Manager) handleVoiceDemo(ctx context.Context, transaction *sentry
 		// all alias the same memory without a copy.
 		frame := make([]byte, encoded)
 		copy(frame, opusBuf[:encoded])
-		select {
-		case <-ticker.C:
-		default:
-			log.Warnf("TTS playback falling behind (ticker missed!)")
-		}
+		<-ticker.C
 		if !trySendOpus(vc, frame) {
 			break
 		}
@@ -395,6 +391,40 @@ func (manager *Manager) handleVoiceDemo(ctx context.Context, transaction *sentry
 
 	// Send followup message with the voice name and the script text
 	manager.SendRequest(interaction, fmt.Sprintf("🎙️ Voice preview (**%s**): *%s*", voice, script), false)
+}
+
+func (manager *Manager) handleVoices(interaction *Interaction) Response {
+	guildID := interaction.GuildID
+	player := manager.Controller.GetPlayer(guildID)
+
+	currentVoice := player.AnnounceVoice
+	if currentVoice == "" && player.DB != nil {
+		if v, _ := player.DB.GetGuildSetting(guildID, "announce_voice"); v != "" {
+			currentVoice = v
+		}
+	}
+	if currentVoice == "" {
+		currentVoice = "Kore"
+	}
+
+	var msg strings.Builder
+	msg.WriteString(fmt.Sprintf("🎙️ **Available TTS Voices** (current: **%s**)\n", currentVoice))
+	for i, v := range gemini.AvailableVoices {
+		if v == currentVoice {
+			msg.WriteString(fmt.Sprintf("`%2d.` **%s** ← active\n", i+1, v))
+		} else {
+			msg.WriteString(fmt.Sprintf("`%2d.` %s\n", i+1, v))
+		}
+	}
+	msg.WriteString("\nUse `/announce voice:<name>` to switch")
+
+	return Response{
+		Type: 4,
+		Data: ResponseData{
+			Content: msg.String(),
+			Flags:   64,
+		},
+	}
 }
 
 // trySendOpus sends opus data to the voice connection, recovering from panics


### PR DESCRIPTION
## Summary
- Apply 2x gain boost to TTS samples during crossfade mixing so announcements cut through
- Replace non-blocking ticker drain (which caused "ticker missed" warnings and bursty sends) with blocking `<-ticker.C`
- Add `/voices` command listing all 30 Gemini TTS voices with the guild's current active voice marked

## Testing
- `go vet ./...` — clean
- `go build ./...` — clean
- `/voices` command registered in `commands.json` and routed in `handlers.go`