### PR TITLE
feat: between-songs TTS announcements instead of crossfade

### DIFF
--- a/audio/player.go
+++ b/audio/player.go
@@ -32,9 +32,7 @@ type Player struct {
 	playbackPosition  atomic.Int64                // microseconds
 	silenceBuffer     []int16                     // Pre-allocated for pause loop
 	silenceOpus       []byte                      // Pre-allocated for pause loop
-	ttsPlayback       atomic.Pointer[TTSPlayback] // pre-generated TTS to mix during crossfade
-	crossfading       atomic.Bool                 // true when crossfade is active
-	crossfadePos      int32                       // frames into the crossfade (NOT atomic — only accessed in Play loop)
+	announcement      atomic.Pointer[TTSPlayback] // pre-generated TTS to play between songs
 }
 
 func NewPlayer() (*Player, error) {
@@ -96,8 +94,6 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 	p.playing.Store(true)
 	p.stopping.Store(false)
 	p.paused.Store(false)
-	p.crossfading.Store(false)
-	p.crossfadePos = 0
 	// Initialize position tracking
 	p.playbackStartTime = time.Now()
 	p.playbackPosition.Store(0)
@@ -217,33 +213,6 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 		for attempts < 3 {
 			err := binary.Read(data.ffmpegOut, binary.LittleEndian, &buffer)
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
-				// If crossfading and TTS still has audio, play remaining TTS solo
-				// using the dedicated TTS encoder to avoid Opus state corruption
-				// from feeding speech into a music-optimized encoder.
-				if p.crossfading.Load() {
-					tts := p.ttsPlayback.Load()
-					if tts != nil && tts.Remaining() > 0 {
-						p.logger.Debug("Music ended, continuing TTS solo")
-						ttsBuf := make([]int16, 960*2)
-						ttsOpusBuf := make([]byte, 960*4)
-						ttsTicker := time.NewTicker(20 * time.Millisecond)
-						for tts.ReadFrame(ttsBuf) {
-							encoded, encErr := p.ttsEncoder.Encode(ttsBuf, ttsOpusBuf)
-							if encErr != nil {
-								break
-							}
-							frame := make([]byte, encoded)
-							copy(frame, ttsOpusBuf[:encoded])
-							if !safeSendOpus(voiceChannel, frame) {
-								break
-							}
-							<-ttsTicker.C
-						}
-						ttsTicker.Stop()
-						p.crossfading.Store(false)
-						p.ttsPlayback.Store(nil)
-					}
-				}
 				p.logger.Trace("Reached end of audio stream")
 				span.Status = sentry.SpanStatusOK
 				p.Notifications <- PlaybackNotification{
@@ -292,47 +261,6 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 			}
 		}
 
-		// Crossfade: fade out music and mix in TTS audio
-		if p.crossfading.Load() {
-			tts := p.ttsPlayback.Load()
-			if tts != nil {
-				// Slow fade-out of music over ~250 frames (5 seconds)
-				const crossfadeDuration int32 = 250
-				p.crossfadePos++
-				t := 1.0 - float64(p.crossfadePos)/float64(crossfadeDuration)
-				if t < 0 {
-					t = 0
-				}
-				musicFade := t * t // quadratic fade
-
-				// Apply music fade
-				for i := range buffer {
-					buffer[i] = int16(float64(buffer[i]) * musicFade)
-				}
-
-				// Mix in TTS audio with 2x gain boost so it cuts through
-				// even when the music hasn't fully faded yet.
-				ttsBuf := make([]int16, 960*2)
-				if tts.ReadFrame(ttsBuf) || tts.Position > 0 {
-					for i := range buffer {
-						boosted := int32(float64(ttsBuf[i]) * 2.0)
-						if boosted > 32767 {
-							boosted = 32767
-						} else if boosted < -32768 {
-							boosted = -32768
-						}
-						mixed := int32(buffer[i]) + boosted
-						if mixed > 32767 {
-							mixed = 32767
-						} else if mixed < -32768 {
-							mixed = -32768
-						}
-						buffer[i] = int16(mixed)
-					}
-				}
-			}
-		}
-
 		encoded, err := p.encoder.Encode(buffer, opusBuffer)
 		if err != nil {
 			p.logger.Warnf("Error encoding to opus: %v", err)
@@ -350,19 +278,6 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 		if !p.paused.Load() && !p.stopping.Load() {
 			currentPos := p.playbackPosition.Load() + 20000 // 20ms in microseconds
 			p.playbackPosition.Store(currentPos)
-		}
-
-		// Check if we should start crossfading (TTS ready + approaching end of song)
-		if !p.crossfading.Load() && data.Duration > 0 {
-			tts := p.ttsPlayback.Load()
-			if tts != nil {
-				remaining := data.Duration - p.GetPosition()
-				if remaining <= 5*time.Second && remaining > 0 {
-					p.crossfading.Store(true)
-					p.crossfadePos = 0
-					p.logger.Debug("Starting TTS crossfade")
-				}
-			}
 		}
 
 		if !safeSendOpus(voiceChannel, opusBuffer[:encoded]) {
@@ -390,13 +305,42 @@ func safeSendOpus(vc *discordgo.VoiceConnection, data []byte) (sent bool) {
 	return true
 }
 
-func (p *Player) SetTTSPlayback(tts *TTSPlayback) {
-	p.ttsPlayback.Store(tts)
+func (p *Player) SetAnnouncement(tts *TTSPlayback) {
+	p.announcement.Store(tts)
 }
 
-func (p *Player) ClearTTSPlayback() {
-	p.ttsPlayback.Store(nil)
-	p.crossfading.Store(false)
+func (p *Player) GetAndClearAnnouncement() *TTSPlayback {
+	tts := p.announcement.Load()
+	p.announcement.Store(nil)
+	return tts
+}
+
+func (p *Player) PlayAnnouncement(tts *TTSPlayback, vc *discordgo.VoiceConnection) error {
+	p.playing.Store(true)
+	defer p.playing.Store(false)
+
+	vc.Speaking(true)
+	defer vc.Speaking(false)
+	time.Sleep(50 * time.Millisecond)
+
+	frameBuf := make([]int16, 960*2)
+	opusBuf := make([]byte, 960*4)
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+
+	for tts.ReadFrame(frameBuf) {
+		encoded, err := p.ttsEncoder.Encode(frameBuf, opusBuf)
+		if err != nil {
+			return err
+		}
+		frame := make([]byte, encoded)
+		copy(frame, opusBuf[:encoded])
+		if !safeSendOpus(vc, frame) {
+			return nil
+		}
+		<-ticker.C
+	}
+	return nil
 }
 
 func (p *Player) Pause(ctx context.Context) {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1106,8 +1106,16 @@ func (p *GuildPlayer) listenForPlaybackEvents() {
 					p.stopNowPlayingUpdates()
 					p.clearNowPlayingCard()
 
-					// Clear any pre-generated TTS so it doesn't carry over
-					p.Player.ClearTTSPlayback()
+					// Play between-songs announcement if one was pre-generated
+					tts := p.Player.GetAndClearAnnouncement()
+					if tts != nil {
+						p.VoiceChannelMutex.RLock()
+						vc := p.VoiceConnection
+						p.VoiceChannelMutex.RUnlock()
+						if vc != nil {
+							p.Player.PlayAnnouncement(tts, vc)
+						}
+					}
 
 					// Loop current song if enabled
 					p.currentItemMutex.RLock()
@@ -1147,6 +1155,11 @@ func (p *GuildPlayer) listenForPlaybackEvents() {
 					// If radio is enabled and queue is empty, auto-queue a similar song
 					if p.IsRadioEnabled() && p.IsEmpty() && p.SongHistory.Len() > 0 {
 						go p.queueRadioSong()
+					}
+
+					// If queue is still empty and announcements are enabled, play "no more songs" TTS
+					if p.IsEmpty() && p.AnnounceEnabled && config.Config.Gemini.Enabled {
+						go p.playNoMoreSongsMessage()
 					}
 				case audio.PlaybackStarted:
 					if queueItem != nil {
@@ -1894,9 +1907,46 @@ func (p *GuildPlayer) preGenerateTTS(currentItem *GuildQueueItem) {
 		return
 	}
 	tts := &audio.TTSPlayback{Samples: samples}
-	p.Player.SetTTSPlayback(tts)
+	p.Player.SetAnnouncement(tts)
 
 	log.Infof("TTS pre-generated for transition: %s → %s", currentSong, nextSong)
+}
+
+// playNoMoreSongsMessage generates and plays a "no more songs" announcement
+// when the queue runs dry. Runs as a goroutine - errors are logged but silent.
+func (p *GuildPlayer) playNoMoreSongsMessage() {
+	ctx, cancel := context.WithTimeout(p.playerCtx, 10*time.Second)
+	defer cancel()
+
+	script := gemini.GenerateRaw(ctx, "Say the queue is empty in a cool radio DJ voice. Mention they can use /queue to add songs or /radio for non-stop music. Keep it to one sentence. No markdown.")
+	if script == "" {
+		script = "That's all for now. Queue up more with /queue, or turn on radio mode with /radio for non-stop tunes."
+	}
+
+	audioBytes, err := gemini.GenerateTTSAudio(ctx, script, p.AnnounceVoice, "")
+	if err != nil {
+		log.Errorf("No-more-songs TTS generation failed: %v", err)
+		return
+	}
+
+	samples, convErr := audio.ConvertTTSToDiscord(audioBytes)
+	if convErr != nil {
+		log.Errorf("No-more-songs audio conversion failed: %v", convErr)
+		return
+	}
+
+	tts := &audio.TTSPlayback{Samples: samples}
+
+	p.VoiceChannelMutex.RLock()
+	vc := p.VoiceConnection
+	p.VoiceChannelMutex.RUnlock()
+	if vc == nil {
+		return
+	}
+
+	if err := p.Player.PlayAnnouncement(tts, vc); err != nil {
+		log.Errorf("No-more-songs announcement playback failed: %v", err)
+	}
 }
 
 // sendNowPlayingCard creates and sends a now-playing embed


### PR DESCRIPTION
## Summary
Removes the crossfade architecture where TTS was mixed into the last 5 seconds of a song. Instead, TTS plays cleanly in the gap between songs with no buffer contention.

## Changes
- **audio/player.go**: Removed `ttsPlayback`, `crossfading`, `crossfadePos` fields. Removed crossfade detection/mixing/solo from `Play()`. Replaced with `SetAnnouncement()`, `GetAndClearAnnouncement()`, and `PlayAnnouncement()` — a standalone method that plays TTS solo using the dedicated `ttsEncoder` with 20ms ticker pacing.

- **controller/controller.go**: On `PlaybackCompleted`, checks for a pre-generated announcement and plays it before calling `playNext()`. Added `playNoMoreSongsMessage()` which generates a "no more songs" TTS on-the-fly when the queue is empty. Updated `preGenerateTTS` to use `SetAnnouncement`.

## Testing
- `go vet ./...` — clean
- `go build ./...` — clean

## Edge cases
- Short songs where TTS isn't ready yet: `GetAndClearAnnouncement()` returns nil → skip gracefully
- No Gemini / announcements disabled: code paths are gated on config
- Empty queue after song: generates fresh "no more songs" TTS via Gemini (Option B — correct even if someone added songs mid-playback)