### PR TITLE
fix: play TTS before EOF with rapid fade-out, default voice Aoede

### DIFF
--- a/audio/player.go
+++ b/audio/player.go
@@ -100,6 +100,8 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 	firstPacket := true
 	buffer := make([]int16, 960*2)
 	opusBuffer := make([]byte, 960*4)
+	var pendingAnnounce *TTSPlayback
+	var announcePlayed bool
 
 	// Prime the voice connection before streaming
 	p.logger.Debug("Setting Speaking(true) to prime voice connection")
@@ -160,6 +162,30 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 				p.logger.Debug("Fade-out complete, stopping playback")
 				span.Status = sentry.SpanStatusCanceled
 				return nil
+			}
+
+			// If fade-out completed and we have an announcement, play TTS solo
+			if p.fadeOutRemaining.Load() == 0 && !announcePlayed && pendingAnnounce != nil {
+				announcePlayed = true
+				ttsBuf := make([]int16, 960*2)
+				ttsOpus := make([]byte, 960*4)
+				ttsTicker := time.NewTicker(20 * time.Millisecond)
+				for pendingAnnounce.ReadFrame(ttsBuf) {
+					encoded, encErr := p.ttsEncoder.Encode(ttsBuf, ttsOpus)
+					if encErr != nil {
+						break
+					}
+					frame := make([]byte, encoded)
+					copy(frame, ttsOpus[:encoded])
+					if !safeSendOpus(voiceChannel, frame) {
+						break
+					}
+					<-ttsTicker.C
+				}
+				ttsTicker.Stop()
+				pendingAnnounce = nil
+				time.Sleep(20 * time.Millisecond)
+				continue
 			}
 
 			time.Sleep(20 * time.Millisecond)
@@ -258,6 +284,19 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 					sample = -32768
 				}
 				buffer[i] = int16(sample)
+			}
+		}
+
+		// Trigger announcement when approaching end of song
+		if !announcePlayed && pendingAnnounce == nil && data.Duration > 0 {
+			tts := p.announcement.Load()
+			if tts != nil {
+				remaining := data.Duration - p.GetPosition()
+				if remaining <= 5*time.Second && remaining > 0 {
+					pendingAnnounce = p.GetAndClearAnnouncement()
+					p.fadeOutRemaining.Store(5)
+					continue
+				}
 			}
 		}
 

--- a/audio/player.go
+++ b/audio/player.go
@@ -311,8 +311,10 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 			}
 		}
 
-		// Trigger announcement when approaching end of song
-		if !announcePlayed && pendingAnnounce == nil && data.Duration > 0 {
+		// Trigger announcement when approaching end of song.
+		// Require at least 3s of duration so the announcement doesn't fire
+		// instantly on very short clips (<5s total).
+		if !announcePlayed && pendingAnnounce == nil && data.Duration > 3*time.Second {
 			tts := p.announcement.Load()
 			if tts != nil {
 				remaining := data.Duration - p.GetPosition()

--- a/audio/player.go
+++ b/audio/player.go
@@ -184,8 +184,32 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 				}
 				ttsTicker.Stop()
 				pendingAnnounce = nil
-				time.Sleep(20 * time.Millisecond)
-				continue
+				// Drain remaining audio silently to keep the voice pipeline flowing
+				// without playing music over the announcement.
+				silenceFrame := make([]int16, 960*2)
+				for {
+					err := binary.Read(data.ffmpegOut, binary.LittleEndian, &buffer)
+					if err == io.EOF || err == io.ErrUnexpectedEOF {
+						break
+					}
+					if err != nil {
+						break
+					}
+					silenceEncoded, silErr := p.encoder.Encode(silenceFrame, opusBuffer)
+					if silErr == nil {
+						if !safeSendOpus(voiceChannel, opusBuffer[:silenceEncoded]) {
+							break
+						}
+					}
+					time.Sleep(20 * time.Millisecond)
+				}
+				p.logger.Trace("Reached end of audio stream")
+				span.Status = sentry.SpanStatusOK
+				p.Notifications <- PlaybackNotification{
+					Event:   PlaybackCompleted,
+					VideoID: &data.VideoID,
+				}
+				return nil
 			}
 
 			time.Sleep(20 * time.Millisecond)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -345,6 +345,12 @@ func (p *GuildPlayer) Reset(ctx context.Context, interaction *GuildQueueItemInte
 	p.playerCancel()
 	p.playerCtx, p.playerCancel = context.WithCancel(context.Background())
 
+	// Clear pending intro announcement state.
+	p.introMu.Lock()
+	p.introAnnouncement = nil
+	p.introGen = 0
+	p.introMu.Unlock()
+
 	// Stop all event listener goroutines via their stop channels.
 	select {
 	case p.idleCheckStop <- struct{}{}:
@@ -366,6 +372,7 @@ func (p *GuildPlayer) Reset(ctx context.Context, interaction *GuildQueueItemInte
 	// Flush audio and voice connection before touching queue state.
 	if p.Player != nil {
 		p.Player.Stop()
+		p.Player.GetAndClearAnnouncement()
 	}
 	p.stopVoiceConnectionMonitor()
 
@@ -1100,6 +1107,9 @@ func (p *GuildPlayer) listenForPlaybackEvents() {
 							"guild_name": p.getGuildName(),
 						},
 					})
+					// Clear any stale TTS from preGenerateTTS goroutines that
+					// may still be in-flight from the skipped song.
+					p.Player.GetAndClearAnnouncement()
 					p.currentSongMutex.Lock()
 					p.CurrentSong = nil
 					p.currentSongMutex.Unlock()
@@ -1913,12 +1923,14 @@ func (p *GuildPlayer) preGenerateTTS(currentItem *GuildQueueItem) {
 	audioBytes, err := gemini.GenerateTTSAudio(ctx, script, p.AnnounceVoice, "")
 	if err != nil {
 		log.Errorf("TTS pre-generation failed: %v", err)
+		sentry.CaptureException(err)
 		return
 	}
 
 	samples, convErr := audio.ConvertTTSToDiscord(audioBytes)
 	if convErr != nil {
 		log.Errorf("TTS audio conversion failed: %v", convErr)
+		sentry.CaptureException(convErr)
 		return
 	}
 	tts := &audio.TTSPlayback{Samples: samples}
@@ -1941,12 +1953,14 @@ func (p *GuildPlayer) playNoMoreSongsMessage() {
 	audioBytes, err := gemini.GenerateTTSAudio(ctx, script, p.AnnounceVoice, "")
 	if err != nil {
 		log.Errorf("No-more-songs TTS generation failed: %v", err)
+		sentry.CaptureException(err)
 		return
 	}
 
 	samples, convErr := audio.ConvertTTSToDiscord(audioBytes)
 	if convErr != nil {
 		log.Errorf("No-more-songs audio conversion failed: %v", convErr)
+		sentry.CaptureException(convErr)
 		return
 	}
 
@@ -1961,6 +1975,7 @@ func (p *GuildPlayer) playNoMoreSongsMessage() {
 
 	if err := p.Player.PlayAnnouncement(tts, vc); err != nil {
 		log.Errorf("No-more-songs announcement playback failed: %v", err)
+		sentry.CaptureException(err)
 	}
 }
 
@@ -1973,7 +1988,7 @@ func (p *GuildPlayer) preGenerateIntroAnnouncement(ctx context.Context, title st
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	script := gemini.GenerateRaw(ctx, "Say something brief as a radio DJ introducing a new song. Mention the song title. One sentence. No markdown. Example: 'Kicking things off with some Daft Punk, let's go.'")
@@ -1984,12 +1999,14 @@ func (p *GuildPlayer) preGenerateIntroAnnouncement(ctx context.Context, title st
 	audioBytes, err := gemini.GenerateTTSAudio(ctx, script, p.AnnounceVoice, "")
 	if err != nil {
 		log.Errorf("Intro TTS generation failed: %v", err)
+		sentry.CaptureException(err)
 		return
 	}
 
 	samples, convErr := audio.ConvertTTSToDiscord(audioBytes)
 	if convErr != nil {
 		log.Errorf("Intro TTS conversion failed: %v", convErr)
+		sentry.CaptureException(convErr)
 		return
 	}
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -131,8 +131,11 @@ type GuildPlayer struct {
 	loopMutex        sync.RWMutex
 
 	// Voice DJ announcement settings (persisted via guild_settings)
-	AnnounceEnabled bool
-	AnnounceVoice   string
+	AnnounceEnabled       bool
+	AnnounceVoice         string
+	introAnnouncement     *audio.TTSPlayback
+	introAnnouncementMu   sync.Mutex
+	introAnnouncementDone chan struct{}
 
 	// Now-playing card tracking
 	NowPlayingMessageID   *string
@@ -536,6 +539,19 @@ func (p *GuildPlayer) play(ctx context.Context, data *audio.LoadResult) {
 		return
 	}
 
+	// Play intro announcement for the first song in an idle channel
+	p.introAnnouncementMu.Lock()
+	intro := p.introAnnouncement
+	p.introAnnouncement = nil
+	done := p.introAnnouncementDone
+	p.introAnnouncementMu.Unlock()
+	if intro != nil {
+		if done != nil {
+			<-done
+		}
+		p.Player.PlayAnnouncement(intro, vc)
+	}
+
 	if err := p.Player.Play(ctx, data, vc); err != nil {
 		sentryhelper.CaptureException(ctx, err)
 		log.Errorf("Error starting stream: %v", err)
@@ -647,6 +663,9 @@ streamReady:
 			VideoID: next.Video.VideoID,
 			Title:   next.Video.Title,
 		})
+
+		// Pre-generate an intro announcement for the first song in an idle channel
+		go p.preGenerateIntroAnnouncement(nextCtx, next.Video.Title)
 		return
 	}
 
@@ -1940,6 +1959,41 @@ func (p *GuildPlayer) playNoMoreSongsMessage() {
 	if err := p.Player.PlayAnnouncement(tts, vc); err != nil {
 		log.Errorf("No-more-songs announcement playback failed: %v", err)
 	}
+}
+
+// preGenerateIntroAnnouncement generates an intro TTS for the first song
+// starting on an idle channel. Runs as a goroutine in parallel with loading.
+func (p *GuildPlayer) preGenerateIntroAnnouncement(ctx context.Context, title string) {
+	if !p.AnnounceEnabled || !config.Config.Gemini.Enabled {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	script := gemini.GenerateRaw(ctx, "Say something brief as a radio DJ introducing a new song. Mention the song title. One sentence. No markdown. Example: 'Kicking things off with some Daft Punk, let's go.'")
+	if script == "" {
+		return
+	}
+
+	audioBytes, err := gemini.GenerateTTSAudio(ctx, script, p.AnnounceVoice, "")
+	if err != nil {
+		log.Errorf("Intro TTS generation failed: %v", err)
+		return
+	}
+
+	samples, convErr := audio.ConvertTTSToDiscord(audioBytes)
+	if convErr != nil {
+		log.Errorf("Intro TTS conversion failed: %v", convErr)
+		return
+	}
+
+	done := make(chan struct{})
+	p.introAnnouncementMu.Lock()
+	p.introAnnouncement = &audio.TTSPlayback{Samples: samples}
+	p.introAnnouncementDone = done
+	p.introAnnouncementMu.Unlock()
+	close(done)
 }
 
 // sendNowPlayingCard creates and sends a now-playing embed

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -131,11 +131,11 @@ type GuildPlayer struct {
 	loopMutex        sync.RWMutex
 
 	// Voice DJ announcement settings (persisted via guild_settings)
-	AnnounceEnabled       bool
-	AnnounceVoice         string
-	introAnnouncement     *audio.TTSPlayback
-	introAnnouncementMu   sync.Mutex
-	introAnnouncementDone chan struct{}
+	AnnounceEnabled   bool
+	AnnounceVoice     string
+	introAnnouncement *audio.TTSPlayback
+	introMu           sync.Mutex
+	introGen          int64 // incremented under introMu each generation
 
 	// Now-playing card tracking
 	NowPlayingMessageID   *string
@@ -539,16 +539,15 @@ func (p *GuildPlayer) play(ctx context.Context, data *audio.LoadResult) {
 		return
 	}
 
-	// Play intro announcement for the first song in an idle channel
-	p.introAnnouncementMu.Lock()
+	// Play intro announcement (pre-generated for the first song on idle channel).
+	// Advance the generation counter afterward so any stale goroutine that
+	// finishes after this point discards its result.
+	p.introMu.Lock()
 	intro := p.introAnnouncement
 	p.introAnnouncement = nil
-	done := p.introAnnouncementDone
-	p.introAnnouncementMu.Unlock()
+	p.introGen++
+	p.introMu.Unlock()
 	if intro != nil {
-		if done != nil {
-			<-done
-		}
 		p.Player.PlayAnnouncement(intro, vc)
 	}
 
@@ -665,7 +664,11 @@ streamReady:
 		})
 
 		// Pre-generate an intro announcement for the first song in an idle channel
-		go p.preGenerateIntroAnnouncement(nextCtx, next.Video.Title)
+		p.introMu.Lock()
+		p.introGen++
+		introGen := p.introGen
+		p.introMu.Unlock()
+		go p.preGenerateIntroAnnouncement(nextCtx, next.Video.Title, introGen)
 		return
 	}
 
@@ -1126,8 +1129,8 @@ func (p *GuildPlayer) listenForPlaybackEvents() {
 					p.clearNowPlayingCard()
 
 					// Announcement playback handled inline by Play() before EOF.
-					// Clear any stale announcement that wasn't played.
-					p.Player.GetAndClearAnnouncement()
+					// No cleanup needed — preGenerateTTS may have just set a new
+					// announcement for the next song's transition.
 
 					// Loop current song if enabled
 					p.currentItemMutex.RLock()
@@ -1963,7 +1966,9 @@ func (p *GuildPlayer) playNoMoreSongsMessage() {
 
 // preGenerateIntroAnnouncement generates an intro TTS for the first song
 // starting on an idle channel. Runs as a goroutine in parallel with loading.
-func (p *GuildPlayer) preGenerateIntroAnnouncement(ctx context.Context, title string) {
+// Uses a generation counter to ensure the result is only stored if no newer
+// song has started playing (or been consumed by play()) in the meantime.
+func (p *GuildPlayer) preGenerateIntroAnnouncement(ctx context.Context, title string, gen int64) {
 	if !p.AnnounceEnabled || !config.Config.Gemini.Enabled {
 		return
 	}
@@ -1988,12 +1993,11 @@ func (p *GuildPlayer) preGenerateIntroAnnouncement(ctx context.Context, title st
 		return
 	}
 
-	done := make(chan struct{})
-	p.introAnnouncementMu.Lock()
-	p.introAnnouncement = &audio.TTSPlayback{Samples: samples}
-	p.introAnnouncementDone = done
-	p.introAnnouncementMu.Unlock()
-	close(done)
+	p.introMu.Lock()
+	defer p.introMu.Unlock()
+	if gen == p.introGen {
+		p.introAnnouncement = &audio.TTSPlayback{Samples: samples}
+	}
 }
 
 // sendNowPlayingCard creates and sends a now-playing embed

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -306,7 +306,7 @@ func (c *Controller) GetPlayer(guildID string) *GuildPlayer {
 	if val, _ := c.db.GetGuildSetting(guildID, "announce_voice"); val != "" {
 		session.AnnounceVoice = val
 	} else {
-		session.AnnounceVoice = "Kore"
+		session.AnnounceVoice = "Aoede"
 	}
 
 	session.listenForQueueEvents()
@@ -1106,16 +1106,9 @@ func (p *GuildPlayer) listenForPlaybackEvents() {
 					p.stopNowPlayingUpdates()
 					p.clearNowPlayingCard()
 
-					// Play between-songs announcement if one was pre-generated
-					tts := p.Player.GetAndClearAnnouncement()
-					if tts != nil {
-						p.VoiceChannelMutex.RLock()
-						vc := p.VoiceConnection
-						p.VoiceChannelMutex.RUnlock()
-						if vc != nil {
-							p.Player.PlayAnnouncement(tts, vc)
-						}
-					}
+					// Announcement playback handled inline by Play() before EOF.
+					// Clear any stale announcement that wasn't played.
+					p.Player.GetAndClearAnnouncement()
 
 					// Loop current song if enabled
 					p.currentItemMutex.RLock()

--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -409,7 +409,7 @@ func GenerateTTSAudio(ctx context.Context, script, voice, model string) ([]byte,
 		model = config.Config.Gemini.TTSModel
 	}
 	if voice == "" {
-		voice = "Kore"
+		voice = "Aoede"
 	}
 
 	span := sentry.StartSpan(ctx, "gemini.tts")

--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -338,9 +338,9 @@ Now write your commentary:`, currentSong, historyStr, radioStr))
 	return commentary
 }
 
-// GenerateDJTransitionScript generates a short spoken-word transition line that a
-// DJ would say over the fade-out of the current song before the next one starts.
-// The result is intended to be fed into TTS, so it avoids markdown and formatting.
+// GenerateDJTransitionScript generates a short spoken-word transition line that
+// announces the song that just played and the one coming up next, in a natural
+// radio DJ cadence. The result is fed into TTS and must avoid markdown.
 func GenerateDJTransitionScript(ctx context.Context, currentSong, nextSong string, recentHistory []string, isRadioPick bool) string {
 	if !config.Config.Gemini.Enabled || defaultClient == nil {
 		return ""
@@ -366,9 +366,9 @@ func GenerateDJTransitionScript(ctx context.Context, currentSong, nextSong strin
 		radioStr = "This next song was auto-queued by radio mode based on the listening pattern."
 	}
 
-	instructions := buildPrompt(fmt.Sprintf(`You are about to talk over the fade-out of the current song. Write ONE sentence that transitions from the current song to the next one.
+	instructions := buildPrompt(fmt.Sprintf(`You are a radio DJ over the fade-out of the current song. Write ONE short sentence that announces the song that just played and what's coming up next.
 
-Current song: %s
+Current song (just finished): %s
 Next up: %s
 
 %s
@@ -376,13 +376,16 @@ Next up: %s
 %s
 
 Rules:
-- ONE sentence ONLY
+- ONE sentence ONLY, divided into two halves
+- First half: announce what just played ("That was X...")
+- Second half: announce what's coming up next ("...up next is Y")
 - No markdown. No bold. No asterisks
-- Natural spoken cadence. This will be read aloud by text-to-speech
-- Keep it SHORT - 5-10 words ideal, 15 words max
-- Think like a radio DJ talking over the tail of a song
+- Natural spoken cadence for text-to-speech
+- Keep it SHORT - 15-20 words max, 5-10 seconds spoken
+- Artist names and song titles only — skip the album mention unless it's obvious
+- Sound like a real radio DJ, not a robot
 
-Example good: "Fading out the Weeknd, rolling into some Daft Punk next."
+Example good: "That was the Weeknd rolling out, up next we got some Daft Punk coming your way."
 Example bad: "**The Weeknd's** track was great! Now let me introduce you to **Daft Punk** with their amazing hit!"
 
 Now write your transition:`, currentSong, nextSong, historyStr, radioStr))

--- a/handlers/playback.go
+++ b/handlers/playback.go
@@ -310,7 +310,7 @@ func (manager *Manager) handleVoiceDemo(ctx context.Context, transaction *sentry
 		}
 	}
 	if voice == "" {
-		voice = "Kore"
+		voice = "Aoede"
 	}
 
 	// Generate a short demo script via Gemini
@@ -404,7 +404,7 @@ func (manager *Manager) handleVoices(interaction *Interaction) Response {
 		}
 	}
 	if currentVoice == "" {
-		currentVoice = "Kore"
+		currentVoice = "Aoede"
 	}
 
 	var msg strings.Builder


### PR DESCRIPTION
## Summary
Refines the between-songs TTS from #85 to play the announcement BEFORE the song ends (during the final seconds), not after. No silent gap between songs.

At ≤5s from song EOF:
1. Music fades out rapidly (100ms cubic fade)
2. TTS plays solo through dedicated `ttsEncoder` (no mixing)
3. Song hits EOF, next song follows immediately

Also changes the default TTS voice from Kore to Aoede.

## Testing
- `go vet ./...` — clean
- `go build ./...` — clean