### PR TITLE
fix: regenerate TTS on queue mutation, fix audio aliasing bugs

### DIFF
--- a/audio/player.go
+++ b/audio/player.go
@@ -150,7 +150,9 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 				p.logger.Warnf("Error encoding during fade-out: %v", err)
 				sentry.CaptureException(err)
 			} else {
-				if !safeSendOpus(voiceChannel, opusBuffer[:encoded]) {
+				frame := make([]byte, encoded)
+				copy(frame, opusBuffer[:encoded])
+				if !safeSendOpus(voiceChannel, frame) {
 					return nil
 				}
 			}
@@ -167,6 +169,9 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 			// If fade-out completed and we have an announcement, play TTS solo
 			if p.fadeOutRemaining.Load() == 0 && !announcePlayed && pendingAnnounce != nil {
 				announcePlayed = true
+				frameCount := 0
+				expectedFrames := pendingAnnounce.Remaining() / (20 * time.Millisecond)
+				p.logger.Debugf("Playing inline announcement: %d expected frames", expectedFrames)
 				ttsBuf := make([]int16, 960*2)
 				ttsOpus := make([]byte, 960*4)
 				ttsTicker := time.NewTicker(20 * time.Millisecond)
@@ -180,9 +185,11 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 					if !safeSendOpus(voiceChannel, frame) {
 						break
 					}
+					frameCount++
 					<-ttsTicker.C
 				}
 				ttsTicker.Stop()
+				p.logger.Debugf("Inline announcement played %d/%d frames", frameCount, expectedFrames)
 				pendingAnnounce = nil
 				// Drain remaining audio silently to keep the voice pipeline flowing
 				// without playing music over the announcement.
@@ -197,7 +204,9 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 					}
 					silenceEncoded, silErr := p.encoder.Encode(silenceFrame, opusBuffer)
 					if silErr == nil {
-						if !safeSendOpus(voiceChannel, opusBuffer[:silenceEncoded]) {
+						silFrame := make([]byte, silenceEncoded)
+						copy(silFrame, opusBuffer[:silenceEncoded])
+						if !safeSendOpus(voiceChannel, silFrame) {
 							break
 						}
 					}
@@ -345,7 +354,9 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 			p.playbackPosition.Store(currentPos)
 		}
 
-		if !safeSendOpus(voiceChannel, opusBuffer[:encoded]) {
+		frame := make([]byte, encoded)
+		copy(frame, opusBuffer[:encoded])
+		if !safeSendOpus(voiceChannel, frame) {
 			p.logger.Debug("Playback stopped - voice channel closed or completed")
 			span.Status = sentry.SpanStatusCanceled
 			p.Notifications <- PlaybackNotification{

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -679,6 +679,11 @@ streamReady:
 		return
 	}
 
+	// Refresh transition TTS when a song is queued while something is playing
+	if p.Player.IsPlaying() {
+		go p.refreshTransitionTTS()
+	}
+
 	index := p.getIndexForItem(event.Item)
 	log.Tracef("song is %d in the queue", index)
 	if index == 0 {
@@ -1888,6 +1893,22 @@ func (p *GuildPlayer) sendRecoveryMessage(message string) {
 // preGenerateTTS generates TTS audio for the transition between the current
 // song and the next song in queue, then sets it on the player for crossfade.
 // Runs as a goroutine - errors are logged but never propagated.
+// refreshTransitionTTS regenerates the between-songs transition TTS based on
+// the current queue state. Call when the queue changes so the announcement
+// always reflects the actual next song.
+func (p *GuildPlayer) refreshTransitionTTS() {
+	if !p.AnnounceEnabled || !config.Config.Gemini.Enabled {
+		return
+	}
+	p.currentItemMutex.RLock()
+	currentItem := p.CurrentItem
+	p.currentItemMutex.RUnlock()
+	if currentItem == nil {
+		return
+	}
+	p.preGenerateTTS(currentItem)
+}
+
 func (p *GuildPlayer) preGenerateTTS(currentItem *GuildQueueItem) {
 	if !p.AnnounceEnabled || !config.Config.Gemini.Enabled {
 		return
@@ -1936,7 +1957,8 @@ func (p *GuildPlayer) preGenerateTTS(currentItem *GuildQueueItem) {
 	tts := &audio.TTSPlayback{Samples: samples}
 	p.Player.SetAnnouncement(tts)
 
-	log.Infof("TTS pre-generated for transition: %s → %s", currentSong, nextSong)
+	log.Infof("TTS pre-generated for transition: %s → %s (script=%d chars, audio=%d bytes, pcm=%d samples)",
+		currentSong, nextSong, len(script), len(audioBytes), len(samples))
 }
 
 // playNoMoreSongsMessage generates and plays a "no more songs" announcement


### PR DESCRIPTION
## Summary

Two fixes from the TTS code review:

**1. Regenerate transition TTS when queue changes**
When a song was added to the queue while something was playing, the pre-generated TTS still announced the old next song. Now refreshTransitionTTS() is called from handleAdd — it regenerates the clip against whatever is currently at the head of the queue. Skip path was already correct (PlaybackStopped clears the announcement via GetAndClearAnnouncement()).

**2. Fix opusBuffer aliasing (audio cutouts)**
All three Opus send paths (fade-out frames, main playback loop, drain loop after TTS) sent opusBuffer[:encoded] directly — a slice that aliases the shared backing buffer. The next iteration's encoder.Encode() overwrites the backing array while Discord's voice goroutine may still be reading the previous frame. This causes silent frame corruption that manifests as audio cutouts.

Fix: make + copy before every safeSendOpus call, matching the pattern already used in the TTS inline playback path.

Also adds frame-count logging to TTS playback (expectedFrames vs frameCount played) to help diagnose any remaining audio issues.

## Testing
- go vet ./... — clean
- go build ./... — clean