### PR TITLE
fix: generate TTS after popQueue, fix refresh guards, force song names in prompt

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -679,8 +679,10 @@ streamReady:
 		return
 	}
 
-	// Refresh transition TTS when a song is queued while something is playing
-	if p.Player.IsPlaying() {
+	// Refresh transition TTS when a song is queued. Use !shouldPlay as the guard
+	// (rather than IsPlaying) because the player may have just finished between
+	// the queue action and this handler running.
+	if !shouldPlay {
 		go p.refreshTransitionTTS()
 	}
 
@@ -1215,9 +1217,6 @@ func (p *GuildPlayer) listenForPlaybackEvents() {
 						// Send now-playing card
 						go p.sendNowPlayingCard(queueItem)
 
-						// Pre-generate TTS for the transition to the next song
-						go p.preGenerateTTS(queueItem)
-
 						// Record in song history for radio mode
 						p.SongHistory.Add(SongHistoryEntry{
 							VideoID: queueItem.Video.VideoID,
@@ -1244,6 +1243,11 @@ func (p *GuildPlayer) listenForPlaybackEvents() {
 					p.speakOnVC(true)
 					// once a song starts playback, we can pop it from the queue
 					p.popQueue()
+					// Pre-generate TTS for transition AFTER popQueue so GetNext()
+					// returns the real next song, not the one that just started.
+					if queueItem != nil {
+						go p.preGenerateTTS(queueItem)
+					}
 					// if there are more songs in the queue, load the next one
 					p.loadNext()
 				case audio.PlaybackError:
@@ -1904,7 +1908,15 @@ func (p *GuildPlayer) refreshTransitionTTS() {
 	currentItem := p.CurrentItem
 	p.currentItemMutex.RUnlock()
 	if currentItem == nil {
-		return
+		// Song just ended and CurrentItem was cleared. Use song history
+		// so the transition can still say "That was X, up next is Y."
+		recent := p.SongHistory.GetRecent(1)
+		if len(recent) == 0 {
+			return
+		}
+		currentItem = &GuildQueueItem{
+			Video: youtube.VideoResponse{Title: recent[0].Title},
+		}
 	}
 	p.preGenerateTTS(currentItem)
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1918,7 +1918,21 @@ func (p *GuildPlayer) refreshTransitionTTS() {
 			Video: youtube.VideoResponse{Title: recent[0].Title},
 		}
 	}
+	// Capture the item identity at start so we can detect if a new song
+	// started while we were generating (refresh runs as a goroutine, and
+	// PlaybackStarted + preGenerateTTS for a new song may have fired).
+	origID := currentItem.Video.VideoID
+
 	p.preGenerateTTS(currentItem)
+
+	// If the current item changed during generation, the announcement we
+	// just set is stale — clear it so the real preGenerateTTS result wins.
+	p.currentItemMutex.RLock()
+	currentItemNow := p.CurrentItem
+	p.currentItemMutex.RUnlock()
+	if currentItemNow != nil && currentItemNow.Video.VideoID != origID {
+		p.Player.GetAndClearAnnouncement()
+	}
 }
 
 func (p *GuildPlayer) preGenerateTTS(currentItem *GuildQueueItem) {
@@ -1928,6 +1942,9 @@ func (p *GuildPlayer) preGenerateTTS(currentItem *GuildQueueItem) {
 
 	nextItem := p.GetNext()
 	if nextItem == nil {
+		// No next song — clear any stale transition that may have been left
+		// by a refresh goroutine that started before the current song did.
+		p.Player.GetAndClearAnnouncement()
 		return
 	}
 

--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -379,14 +379,15 @@ Rules:
 - ONE sentence ONLY, divided into two halves
 - First half: announce what just played ("That was X...")
 - Second half: announce what's coming up next ("...up next is Y")
+- You MUST include BOTH the song/artist that just played AND the song/artist coming up next
+- Never omit either name — they are the entire point of the announcement
 - No markdown. No bold. No asterisks
 - Natural spoken cadence for text-to-speech
 - Keep it SHORT - 15-20 words max, 5-10 seconds spoken
-- Artist names and song titles only — skip the album mention unless it's obvious
 - Sound like a real radio DJ, not a robot
 
 Example good: "That was the Weeknd rolling out, up next we got some Daft Punk coming your way."
-Example bad: "**The Weeknd's** track was great! Now let me introduce you to **Daft Punk** with their amazing hit!"
+Example bad: "This one's just doing its thing."
 
 Now write your transition:`, currentSong, nextSong, historyStr, radioStr))
 


### PR DESCRIPTION
## Summary

Four fixes for the TTS transition regeneration and prompt:

**1. preGenerateTTS was called before popQueue()** — GetNext() returned the current item (still in queue), producing TTS like "Neck Deep → Neck Deep". Moved to after popQueue() so GetNext() returns the actual next song.

**2. refreshTransitionTTS gated on IsPlaying()** — If the song finished between the queue action and handleAdd running, IsPlaying() returned false and refresh was skipped. Changed guard to !shouldPlay.

**3. refreshTransitionTTS returned early when CurrentItem was nil** — After a song finishes, CurrentItem is cleared. refreshTransitionTTS now falls back to SongHistory for the last played song title.

**4. DJ prompt didn't force song names** — Gemini could generate generic responses like "this one's just doing its thing." Now has an ironclad rule: MUST include BOTH song/artist names. Added the bad example explicitly.

## Testing
- go vet ./... — clean
- go build ./... — clean