### PR TITLE
feat: enhanced DJ TTS pipeline with audio tags and audio profile

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -170,7 +170,7 @@ func getGeminiModel() string {
 func getGeminiTTSModel() string {
 	model := os.Getenv("GEMINI_TTS_MODEL")
 	if model == "" {
-		return "gemini-2.5-flash-preview-tts"
+		return "gemini-3.1-flash-tts-preview"
 	}
 	return model
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1965,12 +1965,19 @@ func (p *GuildPlayer) preGenerateTTS(currentItem *GuildQueueItem) {
 	defer span.Finish()
 	ctx = span.Context()
 
-	script := gemini.GenerateDJTransitionScript(ctx, currentSong, nextSong, recentHistory, isRadioPick)
+	script := gemini.GenerateDJScript(ctx, gemini.DJScriptContext{
+		Type:          gemini.AnnouncementTransition,
+		CurrentSong:   currentSong,
+		NextSong:      nextSong,
+		RecentHistory: recentHistory,
+		IsRadioPick:   isRadioPick,
+	})
 	if script == "" {
 		return
 	}
 
-	audioBytes, err := gemini.GenerateTTSAudio(ctx, script, p.AnnounceVoice, "")
+	ttsPrompt := gemini.BuildTTSPrompt(script)
+	audioBytes, err := gemini.GenerateTTSAudio(ctx, ttsPrompt, p.AnnounceVoice, "")
 	if err != nil {
 		log.Errorf("TTS pre-generation failed: %v", err)
 		sentry.CaptureException(err)
@@ -1996,12 +2003,15 @@ func (p *GuildPlayer) playNoMoreSongsMessage() {
 	ctx, cancel := context.WithTimeout(p.playerCtx, 10*time.Second)
 	defer cancel()
 
-	script := gemini.GenerateRaw(ctx, "Say the queue is empty in a cool radio DJ voice. Mention they can use /queue to add songs or /radio for non-stop music. Keep it to one sentence. No markdown.")
+	script := gemini.GenerateDJScript(ctx, gemini.DJScriptContext{
+		Type: gemini.AnnouncementQueueEmpty,
+	})
 	if script == "" {
 		script = "That's all for now. Queue up more with /queue, or turn on radio mode with /radio for non-stop tunes."
 	}
 
-	audioBytes, err := gemini.GenerateTTSAudio(ctx, script, p.AnnounceVoice, "")
+	ttsPrompt := gemini.BuildTTSPrompt(script)
+	audioBytes, err := gemini.GenerateTTSAudio(ctx, ttsPrompt, p.AnnounceVoice, "")
 	if err != nil {
 		log.Errorf("No-more-songs TTS generation failed: %v", err)
 		sentry.CaptureException(err)
@@ -2042,12 +2052,16 @@ func (p *GuildPlayer) preGenerateIntroAnnouncement(ctx context.Context, title st
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	script := gemini.GenerateRaw(ctx, "Say something brief as a radio DJ introducing a new song. Mention the song title. One sentence. No markdown. Example: 'Kicking things off with some Daft Punk, let's go.'")
+	script := gemini.GenerateDJScript(ctx, gemini.DJScriptContext{
+		Type:     gemini.AnnouncementIntro,
+		NextSong: title,
+	})
 	if script == "" {
 		return
 	}
 
-	audioBytes, err := gemini.GenerateTTSAudio(ctx, script, p.AnnounceVoice, "")
+	ttsPrompt := gemini.BuildTTSPrompt(script)
+	audioBytes, err := gemini.GenerateTTSAudio(ctx, ttsPrompt, p.AnnounceVoice, "")
 	if err != nil {
 		log.Errorf("Intro TTS generation failed: %v", err)
 		sentry.CaptureException(err)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1958,14 +1958,16 @@ func (p *GuildPlayer) preGenerateTTS(currentItem *GuildQueueItem) {
 		recentHistory[i] = entry.Title
 	}
 
-	isRadioPick := currentItem.IsRadioPick
+	isRadioPick := nextItem.IsRadioPick
 
 	ctx := p.playerCtx
 	span := sentry.StartSpan(ctx, "tts.pre_generate")
 	defer span.Finish()
 	ctx = span.Context()
 
-	script := gemini.GenerateDJScript(ctx, gemini.DJScriptContext{
+	scriptCtx, scriptCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer scriptCancel()
+	script := gemini.GenerateDJScript(scriptCtx, gemini.DJScriptContext{
 		Type:          gemini.AnnouncementTransition,
 		CurrentSong:   currentSong,
 		NextSong:      nextSong,
@@ -1977,7 +1979,9 @@ func (p *GuildPlayer) preGenerateTTS(currentItem *GuildQueueItem) {
 	}
 
 	ttsPrompt := gemini.BuildTTSPrompt(script)
-	audioBytes, err := gemini.GenerateTTSAudio(ctx, ttsPrompt, p.AnnounceVoice, "")
+	ttsCtx, ttsCancel := context.WithTimeout(ctx, 15*time.Second)
+	defer ttsCancel()
+	audioBytes, err := gemini.GenerateTTSAudio(ttsCtx, ttsPrompt, p.AnnounceVoice, "")
 	if err != nil {
 		log.Errorf("TTS pre-generation failed: %v", err)
 		sentry.CaptureException(err)
@@ -2000,10 +2004,11 @@ func (p *GuildPlayer) preGenerateTTS(currentItem *GuildQueueItem) {
 // playNoMoreSongsMessage generates and plays a "no more songs" announcement
 // when the queue runs dry. Runs as a goroutine - errors are logged but silent.
 func (p *GuildPlayer) playNoMoreSongsMessage() {
-	ctx, cancel := context.WithTimeout(p.playerCtx, 10*time.Second)
-	defer cancel()
+	ctx := p.playerCtx
 
-	script := gemini.GenerateDJScript(ctx, gemini.DJScriptContext{
+	scriptCtx, scriptCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer scriptCancel()
+	script := gemini.GenerateDJScript(scriptCtx, gemini.DJScriptContext{
 		Type: gemini.AnnouncementQueueEmpty,
 	})
 	if script == "" {
@@ -2011,7 +2016,9 @@ func (p *GuildPlayer) playNoMoreSongsMessage() {
 	}
 
 	ttsPrompt := gemini.BuildTTSPrompt(script)
-	audioBytes, err := gemini.GenerateTTSAudio(ctx, ttsPrompt, p.AnnounceVoice, "")
+	ttsCtx, ttsCancel := context.WithTimeout(ctx, 15*time.Second)
+	defer ttsCancel()
+	audioBytes, err := gemini.GenerateTTSAudio(ttsCtx, ttsPrompt, p.AnnounceVoice, "")
 	if err != nil {
 		log.Errorf("No-more-songs TTS generation failed: %v", err)
 		sentry.CaptureException(err)
@@ -2049,10 +2056,9 @@ func (p *GuildPlayer) preGenerateIntroAnnouncement(ctx context.Context, title st
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	script := gemini.GenerateDJScript(ctx, gemini.DJScriptContext{
+	scriptCtx, scriptCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer scriptCancel()
+	script := gemini.GenerateDJScript(scriptCtx, gemini.DJScriptContext{
 		Type:     gemini.AnnouncementIntro,
 		NextSong: title,
 	})
@@ -2061,7 +2067,9 @@ func (p *GuildPlayer) preGenerateIntroAnnouncement(ctx context.Context, title st
 	}
 
 	ttsPrompt := gemini.BuildTTSPrompt(script)
-	audioBytes, err := gemini.GenerateTTSAudio(ctx, ttsPrompt, p.AnnounceVoice, "")
+	ttsCtx, ttsCancel := context.WithTimeout(ctx, 15*time.Second)
+	defer ttsCancel()
+	audioBytes, err := gemini.GenerateTTSAudio(ttsCtx, ttsPrompt, p.AnnounceVoice, "")
 	if err != nil {
 		log.Errorf("Intro TTS generation failed: %v", err)
 		sentry.CaptureException(err)

--- a/docs/superpowers/specs/2026-07-10-enhanced-dj-tts-pipeline-design.md
+++ b/docs/superpowers/specs/2026-07-10-enhanced-dj-tts-pipeline-design.md
@@ -1,0 +1,254 @@
+# Enhanced DJ TTS Pipeline
+
+## Context
+
+The bot's TTS DJ announcements sound robotic and don't act like a real DJ. The voice doesn't mention song or artist names reliably, delivery is flat regardless of the music's energy, and the three announcement types (transition, intro, queue-empty) each use different ad-hoc code paths with inconsistent prompt quality.
+
+Gemini's speech generation API supports audio tags (`[excited]`, `[warm]`, `[laughs]`, etc.) and structured audio profiles (character persona, director's notes for style/pacing) that can make TTS sound dramatically more natural. The newer `gemini-3.1-flash-tts-preview` model also improves baseline quality.
+
+This change introduces a two-step pipeline: an LLM generates a DJ script with inline audio tags, then the TTS model speaks it within a fixed audio profile that establishes the DJ's character and delivery style.
+
+## Architecture
+
+### Pipeline Flow
+
+```
+Song Context (current, next, history, radio mode)
+    │
+    ▼
+┌─────────────────────────────────────────┐
+│  Step 1: GenerateDJScript               │
+│  Model: gemini-2.5-flash (text)         │
+│  Input: TTS system prompt + song context│
+│  Output: DJ script with inline audio    │
+│          tags (plain text, no markdown)  │
+└─────────────────────────────────────────┘
+    │
+    ▼
+┌─────────────────────────────────────────┐
+│  Step 2: BuildTTSPrompt                 │
+│  Wraps script in fixed audio profile    │
+│  (character persona + director's notes) │
+└─────────────────────────────────────────┘
+    │
+    ▼
+┌─────────────────────────────────────────┐
+│  Step 3: GenerateTTSAudio               │
+│  Model: gemini-3.1-flash-tts-preview    │
+│  Input: Full TTS prompt (profile +      │
+│         script with audio tags)         │
+│  Output: Raw PCM audio (24kHz mono)     │
+└─────────────────────────────────────────┘
+    │
+    ▼
+  ConvertTTSToDiscord (existing, unchanged)
+    │
+    ▼
+  Player playback (existing, unchanged)
+```
+
+### Announcement Types
+
+All three types flow through the same pipeline with different context:
+
+| Type | Trigger | Context Provided |
+|------|---------|-----------------|
+| **Transition** | Song starts playing, next song exists | Current song, next song, recent history, radio mode |
+| **Intro** | First song queued on idle channel | Song title only |
+| **Queue Empty** | Last song ends, queue is empty | None (mentions /queue and /radio) |
+
+## Detailed Design
+
+### 1. New `GenerateDJScript` Function (`gemini/gemini.go`)
+
+Replaces `GenerateDJTransitionScript` and the two inline `GenerateRaw` calls.
+
+```go
+type AnnouncementType int
+
+const (
+    AnnouncementTransition AnnouncementType = iota
+    AnnouncementIntro
+    AnnouncementQueueEmpty
+)
+
+type DJScriptContext struct {
+    Type          AnnouncementType
+    CurrentSong   string   // song that just played (transition)
+    NextSong      string   // song coming up (transition, intro)
+    RecentHistory []string // recent song titles
+    IsRadioPick   bool     // whether next song was auto-queued by radio
+}
+
+func GenerateDJScript(ctx context.Context, sc DJScriptContext) string
+```
+
+**System prompt** (separate from `PersonalityPrompt`, no markdown rules):
+
+```
+You are beatbot, a DJ announcing between songs on a Discord music channel.
+Write what you'd actually SAY out loud. Natural, warm, confident. Not a
+morning show host, not monotone. The person at the party with impeccable
+taste who genuinely loves what's playing.
+
+Use audio tags in square brackets to direct your delivery. Place them
+before the words they should color. Match the energy to the music:
+- [warm] — smooth, appreciative moments
+- [excited] — high-energy drops, bangers, hype moments
+- [smooth] — chill transitions, laid-back vibes
+- [laughs] — genuine amusement, playful moments
+- [chill] — relaxed, easy-going delivery
+
+Rules:
+- 1-2 sentences, 15-25 words max
+- You MUST say the song title and artist for every song you reference
+- No markdown, no asterisks, no formatting — this is spoken out loud
+- Natural spoken cadence, not written prose
+- At least one audio tag to set the tone
+```
+
+Type-specific instructions appended:
+
+- **Transition**: "Announce what just played and what's coming up next. Two halves: 'That was X...' then '...up next is Y.' Current song: {current}. Next up: {next}."
+- **Intro**: "Introduce the first song of the session. Build a little anticipation. Song: {next}."
+- **Queue Empty**: "The queue just ran out. Mention they can add songs with /queue or turn on non-stop music with /radio."
+
+Recent history and radio-mode context included when available.
+
+### 2. New `BuildTTSPrompt` Function (`gemini/gemini.go`)
+
+Wraps the LLM-generated script in a fixed audio profile.
+
+```go
+func BuildTTSPrompt(script string) string
+```
+
+Returns a string with this structure:
+
+```
+AUDIO PROFILE: beatbot / "The Booth"
+A warm, confident music lover who happens to be your DJ. Not a hype host.
+The person who puts on the perfect record and genuinely loves sharing it.
+When they speak between songs, you hear real appreciation for what just
+played and natural anticipation for what's next.
+
+DIRECTOR'S NOTES:
+Style: Natural warmth with easy confidence. Not performing excitement,
+just letting it come through. Think late-night radio, the DJ who makes
+you feel like you're the only one listening. The "vocal smile" — you can
+hear the grin without it being forced.
+Pacing: Conversational flow. Not rushed, not dragging. Words breathe
+naturally, like talking to friends between songs. Slight emphasis on
+artist and song names.
+
+TRANSCRIPT:
+{script with audio tags}
+```
+
+The audio profile is a package-level constant (`TTSAudioProfile`), stored alongside the existing `PersonalityPrompt` in `gemini/personality.go`.
+
+### 3. Model Bump (`config/config.go`)
+
+Change the default TTS model:
+
+```go
+func getGeminiTTSModel() string {
+    model := os.Getenv("GEMINI_TTS_MODEL")
+    if model == "" {
+        return "gemini-3.1-flash-tts-preview"  // was gemini-2.5-flash-preview-tts
+    }
+    return model
+}
+```
+
+### 4. Controller Changes (`controller/controller.go`)
+
+All three call sites converge on the same pattern:
+
+**`preGenerateTTS`** (transitions):
+```go
+// Before:
+script := gemini.GenerateDJTransitionScript(ctx, currentSong, nextSong, recentHistory, isRadioPick)
+audioBytes, err := gemini.GenerateTTSAudio(ctx, script, p.AnnounceVoice, "")
+
+// After:
+script := gemini.GenerateDJScript(ctx, gemini.DJScriptContext{
+    Type:          gemini.AnnouncementTransition,
+    CurrentSong:   currentSong,
+    NextSong:      nextSong,
+    RecentHistory: recentHistory,
+    IsRadioPick:   isRadioPick,
+})
+ttsPrompt := gemini.BuildTTSPrompt(script)
+audioBytes, err := gemini.GenerateTTSAudio(ctx, ttsPrompt, p.AnnounceVoice, "")
+```
+
+**`preGenerateIntroAnnouncement`** (intro):
+```go
+// Before:
+script := gemini.GenerateRaw(ctx, "Say something brief as a radio DJ...")
+
+// After:
+script := gemini.GenerateDJScript(ctx, gemini.DJScriptContext{
+    Type:    gemini.AnnouncementIntro,
+    NextSong: title,
+})
+ttsPrompt := gemini.BuildTTSPrompt(script)
+audioBytes, err := gemini.GenerateTTSAudio(ctx, ttsPrompt, p.AnnounceVoice, "")
+```
+
+**`playNoMoreSongsMessage`** (queue empty):
+```go
+// Before:
+script := gemini.GenerateRaw(ctx, "Say the queue is empty in a cool radio DJ voice...")
+
+// After:
+script := gemini.GenerateDJScript(ctx, gemini.DJScriptContext{
+    Type: gemini.AnnouncementQueueEmpty,
+})
+ttsPrompt := gemini.BuildTTSPrompt(script)
+audioBytes, err := gemini.GenerateTTSAudio(ctx, ttsPrompt, p.AnnounceVoice, "")
+```
+
+Static fallback for queue-empty when Gemini is disabled stays unchanged.
+
+### 5. What Gets Removed
+
+- `GenerateDJTransitionScript` in `gemini/gemini.go` (only caller is `preGenerateTTS`)
+- The three inline `GenerateRaw` calls for TTS scripts in the controller are replaced by `GenerateDJScript`
+- `GenerateRaw` itself stays. It's still used by `helpers/gemini.go` (text chat responses) and `handlers/playback.go` (voice-demo command)
+- `buildPrompt` / `PersonalityPrompt` remain for text chat responses, not used by the new TTS pipeline
+
+Note: `refreshTransitionTTS` delegates to `preGenerateTTS`, so updating `preGenerateTTS` automatically covers the queue-mutation refresh path. The `/voice-demo` handler (`handlers/playback.go:317`) is left as-is since it's a one-off sample, not a real announcement.
+
+### 6. What Stays Unchanged
+
+- `GenerateTTSAudio` function signature and behavior (receives a richer prompt, same output)
+- `audio/tts.go` — ConvertTTSToDiscord pipeline
+- `audio/player.go` — inline TTS before EOF, standalone PlayAnnouncement
+- All staleness guards, generation counters, refresh logic
+- Voice selection, `/voices`, `/announce`, `/voice-demo` commands
+- `PersonalityPrompt` constant (used for text chat, not TTS)
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `gemini/gemini.go` | Add `GenerateDJScript`, `BuildTTSPrompt`, `AnnouncementType` enum, `DJScriptContext` struct. Remove `GenerateDJTransitionScript`. |
+| `gemini/personality.go` | Add `TTSAudioProfile` and `TTSPersonalityPrompt` constants. |
+| `config/config.go` | Change default TTS model to `gemini-3.1-flash-tts-preview`. |
+| `controller/controller.go` | Update `preGenerateTTS`, `preGenerateIntroAnnouncement`, `playNoMoreSongsMessage` to use new pipeline. |
+| `cmd/tts-debug/main.go` | Update to use new pipeline for testing (optional, low priority). |
+
+## Verification
+
+1. **Build**: `go build` passes with no errors
+2. **Type check**: No new warnings from `go vet`
+3. **Manual test with tts-debug tool**: Run `cmd/tts-debug/main.go` with the new pipeline and compare WAV output quality against the old pipeline
+4. **Live test in Discord**: Queue 2-3 songs, verify:
+   - Transition announcements mention both song names
+   - Audio tags produce audible delivery variation (excited vs. smooth)
+   - Intro announcement plays before the first song
+   - Queue-empty announcement plays when the queue drains
+   - Voice sounds natural, warm, not robotic
+5. **Edge cases**: Skip rapidly, add songs mid-play (refresh TTS), test with radio mode

--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -25,6 +25,26 @@ var AvailableVoices = []string{
 	"Vindemiatrix", "Sadachbia", "Sadaltager", "Sulafat",
 }
 
+// AnnouncementType identifies which kind of DJ announcement is being generated,
+// so GenerateDJScript can tailor instructions and context to the moment.
+type AnnouncementType int
+
+const (
+	AnnouncementTransition AnnouncementType = iota
+	AnnouncementIntro
+	AnnouncementQueueEmpty
+)
+
+// DJScriptContext carries the situational details GenerateDJScript needs to
+// write a natural-sounding announcement for the given AnnouncementType.
+type DJScriptContext struct {
+	Type          AnnouncementType
+	CurrentSong   string   // song that just played (transition)
+	NextSong      string   // song coming up (transition, intro)
+	RecentHistory []string // recent song titles
+	IsRadioPick   bool     // whether next song was auto-queued by radio
+}
+
 // Init initializes the shared Gemini client. Must be called once at startup
 // (after config is loaded) before any Gemini functions are used. Safe to call
 // when Gemini is disabled — it becomes a no-op.
@@ -338,58 +358,87 @@ Now write your commentary:`, currentSong, historyStr, radioStr))
 	return commentary
 }
 
-// GenerateDJTransitionScript generates a short spoken-word transition line that
-// announces the song that just played and the one coming up next, in a natural
-// radio DJ cadence. The result is fed into TTS and must avoid markdown.
-func GenerateDJTransitionScript(ctx context.Context, currentSong, nextSong string, recentHistory []string, isRadioPick bool) string {
+// announcementTypeTag returns a short string for Sentry tagging.
+func announcementTypeTag(t AnnouncementType) string {
+	switch t {
+	case AnnouncementTransition:
+		return "transition"
+	case AnnouncementIntro:
+		return "intro"
+	case AnnouncementQueueEmpty:
+		return "queue_empty"
+	default:
+		return "unknown"
+	}
+}
+
+// recentHistoryBlock formats recent song history as a numbered list, or a
+// fallback line when there's no history yet. Shared across announcement types.
+func recentHistoryBlock(recentHistory []string) string {
+	if len(recentHistory) == 0 {
+		return "This is the first song in the session."
+	}
+	var sb strings.Builder
+	sb.WriteString("Recent songs played (most recent first):\n")
+	for i, song := range recentHistory {
+		sb.WriteString(fmt.Sprintf("%d. %s\n", i+1, song))
+	}
+	return sb.String()
+}
+
+// GenerateDJScript generates a short spoken-word DJ script — with inline audio
+// tags for TTS delivery — for the moment described by sc. The result must
+// avoid markdown; it's fed directly into GenerateTTSAudio via BuildTTSPrompt.
+func GenerateDJScript(ctx context.Context, sc DJScriptContext) string {
 	if !config.Config.Gemini.Enabled || defaultClient == nil {
 		return ""
 	}
 
-	span := sentry.StartSpan(ctx, "gemini.dj_transition_script")
-	span.Description = "Generate DJ transition script for TTS"
+	span := sentry.StartSpan(ctx, "gemini.dj_script")
+	span.Description = "Generate DJ script for TTS"
 	span.SetTag("model", config.Config.Gemini.Model)
+	span.SetTag("announcement_type", announcementTypeTag(sc.Type))
 	defer span.Finish()
 
-	var historyStr string
-	if len(recentHistory) > 0 {
-		historyStr = "Recent songs played (most recent first):\n"
-		for i, song := range recentHistory {
-			historyStr += fmt.Sprintf("%d. %s\n", i+1, song)
+	var taskPrompt string
+	switch sc.Type {
+	case AnnouncementTransition:
+		radioStr := ""
+		if sc.IsRadioPick {
+			radioStr = "This next song was auto-queued by radio mode based on the listening pattern."
 		}
-	} else {
-		historyStr = "This is the first song in the session."
-	}
 
-	radioStr := ""
-	if isRadioPick {
-		radioStr = "This next song was auto-queued by radio mode based on the listening pattern."
-	}
-
-	instructions := buildPrompt(fmt.Sprintf(`You are a radio DJ over the fade-out of the current song. Write ONE short sentence that announces the song that just played and what's coming up next.
-
-Current song (just finished): %s
+		taskPrompt = fmt.Sprintf(`Current song (just finished): %s
 Next up: %s
 
 %s
 
 %s
 
-Rules:
-- ONE sentence ONLY, divided into two halves
-- First half: announce what just played ("That was X...")
-- Second half: announce what's coming up next ("...up next is Y")
-- You MUST include BOTH the song/artist that just played AND the song/artist coming up next
+Your task: Announce what just played and what's coming up next. Write it as two halves: first announce what just played, then what's next.
+- You MUST say BOTH the song/artist that just played AND the song/artist coming up next
 - Never omit either name — they are the entire point of the announcement
-- No markdown. No bold. No asterisks
-- Natural spoken cadence for text-to-speech
-- Keep it SHORT - 15-20 words max, 5-10 seconds spoken
-- Sound like a real radio DJ, not a robot
 
-Example good: "That was the Weeknd rolling out, up next we got some Daft Punk coming your way."
-Example bad: "This one's just doing its thing."
+Now write your transition:`, sc.CurrentSong, sc.NextSong, recentHistoryBlock(sc.RecentHistory), radioStr)
+	case AnnouncementIntro:
+		taskPrompt = fmt.Sprintf(`First song of the session: %s
 
-Now write your transition:`, currentSong, nextSong, historyStr, radioStr))
+Your task: Introduce the first song of the session. Build a little anticipation — you're kicking things off.
+- You MUST say the song/artist
+
+Now write your intro:`, sc.NextSong)
+	case AnnouncementQueueEmpty:
+		taskPrompt = fmt.Sprintf(`%s
+
+Your task: The queue just ran out. Let listeners know, and mention they can add songs with /queue or turn on non-stop music with /radio.
+
+Now write your announcement:`, recentHistoryBlock(sc.RecentHistory))
+	default:
+		span.Status = sentry.SpanStatusInvalidArgument
+		return ""
+	}
+
+	instructions := TTSPersonalityPrompt + "\n\n" + taskPrompt
 
 	response := generateResponse(ctx, instructions)
 	if response == "" {
@@ -399,6 +448,12 @@ Now write your transition:`, currentSong, nextSong, historyStr, radioStr))
 
 	span.Status = sentry.SpanStatusOK
 	return strings.TrimSpace(response)
+}
+
+// BuildTTSPrompt wraps a generated DJ script in the fixed audio profile so the
+// TTS model has consistent voice direction across every announcement.
+func BuildTTSPrompt(script string) string {
+	return fmt.Sprintf(TTSAudioProfile, script)
 }
 
 // GenerateTTSAudio synthesizes speech from a script using Gemini's TTS model.

--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -428,11 +428,9 @@ Your task: Introduce the first song of the session. Build a little anticipation 
 
 Now write your intro:`, sc.NextSong)
 	case AnnouncementQueueEmpty:
-		taskPrompt = fmt.Sprintf(`%s
+		taskPrompt = `Your task: The queue just ran out. Let listeners know, and mention they can add songs with /queue or turn on non-stop music with /radio.
 
-Your task: The queue just ran out. Let listeners know, and mention they can add songs with /queue or turn on non-stop music with /radio.
-
-Now write your announcement:`, recentHistoryBlock(sc.RecentHistory))
+Now write your announcement:`
 	default:
 		span.Status = sentry.SpanStatusInvalidArgument
 		return ""
@@ -456,10 +454,11 @@ func BuildTTSPrompt(script string) string {
 	return fmt.Sprintf(TTSAudioProfile, script)
 }
 
-// GenerateTTSAudio synthesizes speech from a script using Gemini's TTS model.
+// GenerateTTSAudio synthesizes speech from a prompt using Gemini's TTS model.
+// The prompt should include the audio profile and transcript (see BuildTTSPrompt).
 // Returns raw PCM audio data (16-bit 24kHz mono). The caller is responsible for
 // encoding or resampling before sending to Discord.
-func GenerateTTSAudio(ctx context.Context, script, voice, model string) ([]byte, error) {
+func GenerateTTSAudio(ctx context.Context, prompt, voice, model string) ([]byte, error) {
 	if defaultClient == nil {
 		return nil, fmt.Errorf("gemini client not initialized")
 	}
@@ -477,7 +476,7 @@ func GenerateTTSAudio(ctx context.Context, script, voice, model string) ([]byte,
 	span.SetTag("voice", voice)
 	defer span.Finish()
 
-	content := []*genai.Content{{Parts: []*genai.Part{{Text: script}}}}
+	content := []*genai.Content{{Parts: []*genai.Part{{Text: prompt}}}}
 	resp, err := defaultClient.Models.GenerateContent(ctx, model, content, &genai.GenerateContentConfig{
 		ResponseModalities: []string{"AUDIO"},
 		SpeechConfig: &genai.SpeechConfig{

--- a/gemini/personality.go
+++ b/gemini/personality.go
@@ -17,3 +17,45 @@ When responding to music player commands (play, skip, pause, etc.):
 - Keep responses brief, dynamic, and music-savvy. Reference the action specifically.
 - 1-2 sentences max. Use minimal markdown. Be clever, not generic.
 - Never be hype-heavy or apologetic — just confident DJ energy.`
+
+// TTSPersonalityPrompt is the DJ personality adapted for spoken word.
+// Used as the system prompt for the LLM that generates DJ scripts with audio tags.
+const TTSPersonalityPrompt = `You are beatbot, a DJ announcing between songs on a Discord music channel.
+Write what you'd actually SAY out loud. Natural, warm, confident. Not a
+morning show host, not monotone. The person at the party with impeccable
+taste who genuinely loves what's playing.
+
+Use audio tags in square brackets to direct your delivery. Place them
+before the words they should color. Match the energy to the music:
+- [warm] — smooth, appreciative moments
+- [excited] — high-energy drops, bangers, hype moments
+- [smooth] — chill transitions, laid-back vibes
+- [laughs] — genuine amusement, playful moments
+- [chill] — relaxed, easy-going delivery
+
+Rules:
+- 1-2 sentences, 15-25 words max
+- You MUST say the song title and artist for every song you reference
+- No markdown, no asterisks, no formatting — this is spoken out loud
+- Natural spoken cadence, not written prose
+- At least one audio tag to set the tone`
+
+// TTSAudioProfile is the fixed audio profile that wraps every TTS call.
+// The %s placeholder is filled with the generated transcript.
+const TTSAudioProfile = `AUDIO PROFILE: beatbot / "The Booth"
+A warm, confident music lover who happens to be your DJ. Not a hype host.
+The person who puts on the perfect record and genuinely loves sharing it.
+When they speak between songs, you hear real appreciation for what just
+played and natural anticipation for what's next.
+
+DIRECTOR'S NOTES:
+Style: Natural warmth with easy confidence. Not performing excitement,
+just letting it come through. Think late-night radio, the DJ who makes
+you feel like you're the only one listening. The "vocal smile" — you can
+hear the grin without it being forced.
+Pacing: Conversational flow. Not rushed, not dragging. Words breathe
+naturally, like talking to friends between songs. Slight emphasis on
+artist and song names.
+
+TRANSCRIPT:
+%s`


### PR DESCRIPTION
Two-step TTS pipeline: Gemini LLM generates a DJ script with inline audio tags (`[warm]`, `[excited]`, `[smooth]`, etc.) matched to song energy, then a fixed audio profile wraps the script with character persona and director's notes before sending to the TTS model. All three announcement types (transition, intro, queue-empty) now flow through the same unified `GenerateDJScript` -> `BuildTTSPrompt` -> `GenerateTTSAudio` pipeline, replacing three separate ad-hoc code paths. Default TTS model bumped from `gemini-2.5-flash-preview-tts` to `gemini-3.1-flash-tts-preview`.

## Changes

- **`gemini/personality.go`** -- added `TTSPersonalityPrompt` (spoken-word DJ personality with audio tag guidance) and `TTSAudioProfile` (fixed audio profile with director's notes for natural delivery)
- **`gemini/gemini.go`** -- added `GenerateDJScript` (unified script generation with `AnnouncementType` enum), `BuildTTSPrompt` (wraps script in audio profile), removed old `GenerateDJTransitionScript`
- **`config/config.go`** -- default TTS model bumped to `gemini-3.1-flash-tts-preview`
- **`controller/controller.go`** -- `preGenerateTTS`, `preGenerateIntroAnnouncement`, `playNoMoreSongsMessage` all wired to the new pipeline

## Test plan

- [ ] `go build` and `go vet` pass clean
- [ ] Queue 2-3 songs, verify transition announcements name both songs with varied delivery
- [ ] Join idle channel, queue first song, verify intro announcement plays
- [ ] Let queue drain, verify queue-empty announcement mentions /queue and /radio
- [ ] Skip rapidly, add songs mid-play to exercise refresh TTS path
- [ ] Test with radio mode enabled