### PR TITLE
fix: prevent same-song TTS transitions and stale overwrites

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -136,6 +136,8 @@ type GuildPlayer struct {
 	introAnnouncement *audio.TTSPlayback
 	introMu           sync.Mutex
 	introGen          int64 // incremented under introMu each generation
+	ttsMu             sync.Mutex
+	ttsGen            int64 // incremented each time a TTS generation starts
 
 	// Now-playing card tracking
 	NowPlayingMessageID   *string
@@ -1940,11 +1942,24 @@ func (p *GuildPlayer) preGenerateTTS(currentItem *GuildQueueItem) {
 		return
 	}
 
+	// Claim a generation slot so stale goroutines can't overwrite newer results.
+	p.ttsMu.Lock()
+	p.ttsGen++
+	myGen := p.ttsGen
+	p.ttsMu.Unlock()
+
 	nextItem := p.GetNext()
 	if nextItem == nil {
 		// No next song — clear any stale transition that may have been left
 		// by a refresh goroutine that started before the current song did.
 		p.Player.GetAndClearAnnouncement()
+		return
+	}
+
+	// Guard against "X → X" transitions caused by GetNext() seeing the queue
+	// before popQueue has drained the currently-playing song.
+	if nextItem.Video.VideoID == currentItem.Video.VideoID {
+		log.Debugf("TTS skipped: next song is same as current (%s)", currentItem.Video.Title)
 		return
 	}
 
@@ -1994,6 +2009,17 @@ func (p *GuildPlayer) preGenerateTTS(currentItem *GuildQueueItem) {
 		sentry.CaptureException(convErr)
 		return
 	}
+
+	// Check if a newer generation started while we were making API calls.
+	// If so, our result is stale — don't overwrite.
+	p.ttsMu.Lock()
+	stale := myGen != p.ttsGen
+	p.ttsMu.Unlock()
+	if stale {
+		log.Debugf("TTS generation %d superseded by %d, discarding", myGen, p.ttsGen)
+		return
+	}
+
 	tts := &audio.TTSPlayback{Samples: samples}
 	p.Player.SetAnnouncement(tts)
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1247,9 +1247,7 @@ func (p *GuildPlayer) listenForPlaybackEvents() {
 					p.popQueue()
 					// Pre-generate TTS for transition AFTER popQueue so GetNext()
 					// returns the real next song, not the one that just started.
-					if queueItem != nil {
-						go p.preGenerateTTS(queueItem)
-					}
+					go p.preGenerateTTS()
 					// if there are more songs in the queue, load the next one
 					p.loadNext()
 				case audio.PlaybackError:
@@ -1903,41 +1901,10 @@ func (p *GuildPlayer) sendRecoveryMessage(message string) {
 // the current queue state. Call when the queue changes so the announcement
 // always reflects the actual next song.
 func (p *GuildPlayer) refreshTransitionTTS() {
-	if !p.AnnounceEnabled || !config.Config.Gemini.Enabled {
-		return
-	}
-	p.currentItemMutex.RLock()
-	currentItem := p.CurrentItem
-	p.currentItemMutex.RUnlock()
-	if currentItem == nil {
-		// Song just ended and CurrentItem was cleared. Use song history
-		// so the transition can still say "That was X, up next is Y."
-		recent := p.SongHistory.GetRecent(1)
-		if len(recent) == 0 {
-			return
-		}
-		currentItem = &GuildQueueItem{
-			Video: youtube.VideoResponse{Title: recent[0].Title},
-		}
-	}
-	// Capture the item identity at start so we can detect if a new song
-	// started while we were generating (refresh runs as a goroutine, and
-	// PlaybackStarted + preGenerateTTS for a new song may have fired).
-	origID := currentItem.Video.VideoID
-
-	p.preGenerateTTS(currentItem)
-
-	// If the current item changed during generation, the announcement we
-	// just set is stale — clear it so the real preGenerateTTS result wins.
-	p.currentItemMutex.RLock()
-	currentItemNow := p.CurrentItem
-	p.currentItemMutex.RUnlock()
-	if currentItemNow != nil && currentItemNow.Video.VideoID != origID {
-		p.Player.GetAndClearAnnouncement()
-	}
+	p.preGenerateTTS()
 }
 
-func (p *GuildPlayer) preGenerateTTS(currentItem *GuildQueueItem) {
+func (p *GuildPlayer) preGenerateTTS() {
 	if !p.AnnounceEnabled || !config.Config.Gemini.Enabled {
 		return
 	}
@@ -1948,22 +1915,27 @@ func (p *GuildPlayer) preGenerateTTS(currentItem *GuildQueueItem) {
 	myGen := p.ttsGen
 	p.ttsMu.Unlock()
 
+	// Use SongHistory as the source of truth for "currently playing."
+	// The history is written in PlaybackStarted before popQueue, so it's
+	// always accurate regardless of queue mutation timing.
+	recent := p.SongHistory.GetRecent(1)
+	if len(recent) == 0 {
+		return
+	}
+	currentSong := recent[0].Title
+	currentVideoID := recent[0].VideoID
+
 	nextItem := p.GetNext()
 	if nextItem == nil {
-		// No next song — clear any stale transition that may have been left
-		// by a refresh goroutine that started before the current song did.
 		p.Player.GetAndClearAnnouncement()
 		return
 	}
 
-	// Guard against "X → X" transitions caused by GetNext() seeing the queue
-	// before popQueue has drained the currently-playing song.
-	if nextItem.Video.VideoID == currentItem.Video.VideoID {
-		log.Debugf("TTS skipped: next song is same as current (%s)", currentItem.Video.Title)
+	// Guard against announcing "X → X" if the queue hasn't been drained yet.
+	if nextItem.Video.VideoID == currentVideoID {
 		return
 	}
 
-	currentSong := currentItem.Video.Title
 	nextSong := nextItem.Video.Title
 
 	// Build recent history titles


### PR DESCRIPTION
Two bugs caused the DJ to announce "Gnarwolves -> Gnarwolves" instead of the correct next song.

**Bug 1: Same-song transition.** `preGenerateTTS` could call `GetNext()` before `popQueue` fully drained the currently-playing song from the queue, returning the current song as "next". Added a VideoID guard that bails when nextItem matches currentItem.

**Bug 2: Stale overwrite.** When a new song was queued (triggering `refreshTransitionTTS`), the original `preGenerateTTS` goroutine could finish its Gemini API calls later and overwrite the correct "Gnarwolves -> BAD NERVES" result with its stale "Gnarwolves -> Gnarwolves". Added a `ttsGen` counter (same pattern as the existing `introGen`) so stale generations discard their results.

## Test plan

- [ ] `go build` and `go vet` clean
- [ ] Queue a song in radio mode, verify transition announces the correct next song (not the same song twice)
- [ ] Add a song mid-playback, verify refreshTransitionTTS wins over the original