### PR TITLE
fix: add TTS timing debug logs, remove join announcement

### DIFF
--- a/audio/player.go
+++ b/audio/player.go
@@ -332,15 +332,32 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 		// Check the time window BEFORE consuming: ConsumeTTS() is destructive
 		// (read-and-clear), so we must only call it when we're ready to use
 		// the buffer. Otherwise the TTS is consumed early and lost.
-		if !announcePlayed && pendingAnnounce == nil && data.Duration > 3*time.Second && p.ttsConsumer != nil {
-			remaining := data.Duration - p.GetPosition()
-			if remaining <= 5*time.Second && remaining > 0 {
+		if !announcePlayed && pendingAnnounce == nil && p.ttsConsumer != nil {
+			pos := p.GetPosition()
+			remaining := data.Duration - pos
+
+			// Log periodically (every ~10 seconds) so we can trace timing
+			if pos > 0 && pos%(10*time.Second) < 20*time.Millisecond {
+				p.logger.Debugf("[tts-check] duration=%s pos=%s remaining=%s hasTTS=%v",
+					data.Duration, pos, remaining, p.ttsConsumer != nil)
+			}
+
+			if data.Duration > 3*time.Second && remaining <= 5*time.Second && remaining > 0 {
 				tts := p.ttsConsumer.ConsumeTTS()
 				if tts != nil {
+					p.logger.Debug("[tts-check] Starting TTS crossfade")
 					pendingAnnounce = tts
 					p.fadeOutRemaining.Store(5)
 					continue
+				} else {
+					p.logger.Debug("[tts-check] In 5s window but ConsumeTTS returned nil")
 				}
+			}
+
+			// Log once when we pass the 5-second mark without triggering
+			if data.Duration > 3*time.Second && remaining <= 0 && !announcePlayed {
+				p.logger.Warnf("[tts-check] Song ended without TTS trigger: duration=%s pos=%s remaining=%s",
+					data.Duration, pos, remaining)
 			}
 		}
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -710,9 +710,6 @@ func (p *GuildPlayer) JoinVoiceChannel(userID string) error {
 	// Start monitoring voice connection health
 	p.startVoiceConnectionMonitor()
 
-	// Play a join announcement the first time the bot enters voice
-	go p.playJoinAnnouncement(vc)
-
 	// Add breadcrumb for voice channel join (uses global scope since this is a guild-level operation)
 	sentry.AddBreadcrumb(&sentry.Breadcrumb{
 		Category: "voice",
@@ -2071,48 +2068,6 @@ func (p *GuildPlayer) playNoMoreSongsMessage() {
 
 	if err := p.Player.PlayAnnouncement(tts, vc); err != nil {
 		log.Errorf("No-more-songs announcement playback failed: %v", err)
-		sentry.CaptureException(err)
-	}
-}
-
-// playJoinAnnouncement generates and plays a DJ intro when the bot first
-// joins a voice channel. Runs as a goroutine from JoinVoiceChannel.
-func (p *GuildPlayer) playJoinAnnouncement(vc *discordgo.VoiceConnection) {
-	if !p.GetAnnounceEnabled() || !config.Config.Gemini.Enabled {
-		return
-	}
-
-	ctx := p.playerCtx
-
-	scriptCtx, scriptCancel := context.WithTimeout(ctx, 10*time.Second)
-	defer scriptCancel()
-	script := gemini.GenerateDJScript(scriptCtx, gemini.DJScriptContext{
-		Type: gemini.AnnouncementJoin,
-	})
-	if script == "" {
-		return
-	}
-
-	ttsPrompt := gemini.BuildTTSPrompt(script)
-	ttsCtx, ttsCancel := context.WithTimeout(ctx, 15*time.Second)
-	defer ttsCancel()
-	audioBytes, err := gemini.GenerateTTSAudio(ttsCtx, ttsPrompt, p.GetAnnounceVoice(), "")
-	if err != nil {
-		log.Errorf("Join announcement TTS generation failed: %v", err)
-		sentry.CaptureException(err)
-		return
-	}
-
-	samples, convErr := audio.ConvertTTSToDiscord(audioBytes)
-	if convErr != nil {
-		log.Errorf("Join announcement TTS conversion failed: %v", convErr)
-		sentry.CaptureException(convErr)
-		return
-	}
-
-	tts := &audio.TTSPlayback{Samples: samples}
-	if err := p.Player.PlayAnnouncement(tts, vc); err != nil {
-		log.Errorf("Join announcement playback failed: %v", err)
 		sentry.CaptureException(err)
 	}
 }

--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -33,7 +33,6 @@ const (
 	AnnouncementTransition AnnouncementType = iota
 	AnnouncementIntro
 	AnnouncementQueueEmpty
-	AnnouncementJoin
 )
 
 // DJScriptContext carries the situational details GenerateDJScript needs to
@@ -368,8 +367,6 @@ func announcementTypeTag(t AnnouncementType) string {
 		return "intro"
 	case AnnouncementQueueEmpty:
 		return "queue_empty"
-	case AnnouncementJoin:
-		return "join"
 	default:
 		return "unknown"
 	}
@@ -434,10 +431,6 @@ Now write your intro:`, sc.NextSong)
 		taskPrompt = `Your task: The queue just ran out. Let listeners know, and mention they can add songs with /queue or turn on non-stop music with /radio.
 
 Now write your announcement:`
-	case AnnouncementJoin:
-		taskPrompt = `Your task: You just joined the voice channel. Introduce yourself briefly. You're the DJ. Tell them to queue up some songs with /play or /queue. Keep it casual and brief.
-
-Now write your intro:`
 	default:
 		span.Status = sentry.SpanStatusInvalidArgument
 		return ""


### PR DESCRIPTION
## Summary

- **Verbose TTS debug logging**: The transition TTS generates correctly but never plays. Added `[tts-check]` logs to Player.Play() that report duration/position/remaining every ~10s, log when entering the 5s window (with or without buffer), and warn if the song ends without TTS triggering. This will show exactly which condition is failing.
- **Removed join announcement**: Since the bot only joins voice when a song is queued, the TTS was playing over the music. Removed `playJoinAnnouncement`, `AnnouncementJoin` type, and the call from `JoinVoiceChannel`.

## Test plan

- [ ] `go build` and `go vet` pass
- [ ] Deploy, queue 2 songs, check logs for `[tts-check]` entries showing duration/position/remaining progression
- [ ] The logs will reveal why the 5s window check is failing