### PR TITLE
feat: DJ mentions who queued songs, hype radio on queue-empty

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1172,6 +1172,7 @@ func (p *GuildPlayer) listenForPlaybackEvents() {
 							Title:       queueItem.Video.Title,
 							VideoID:     queueItem.Video.VideoID,
 							IsRadioPick: queueItem.IsRadioPick,
+							QueuedBy:    p.resolveQueuedBy(queueItem),
 						})
 						p.currentItemMutex.Lock()
 						p.CurrentItem = queueItem
@@ -1915,6 +1916,16 @@ func (p *GuildPlayer) sendRecoveryMessage(message string) {
 
 // syncNextFromQueue reads the queue's next item and pushes it into PlaybackState.
 // Call after queue mutations that may change the next-queued item.
+func (p *GuildPlayer) resolveQueuedBy(item *GuildQueueItem) string {
+	if item == nil || item.Interaction == nil || item.Interaction.UserID == "" {
+		return ""
+	}
+	if p.DB != nil {
+		return p.DB.GetOrFetchUsername(p.GuildID, item.Interaction.UserID)
+	}
+	return ""
+}
+
 func (p *GuildPlayer) syncNextFromQueue() {
 	next := p.GetNext()
 	if next != nil {
@@ -1922,6 +1933,7 @@ func (p *GuildPlayer) syncNextFromQueue() {
 			Title:       next.Video.Title,
 			VideoID:     next.Video.VideoID,
 			IsRadioPick: next.IsRadioPick,
+			QueuedBy:    p.resolveQueuedBy(next),
 		})
 	} else {
 		p.playbackState.ClearNext()
@@ -1990,11 +2002,13 @@ func (p *GuildPlayer) generateTransitionTTS() {
 	scriptCtx, scriptCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer scriptCancel()
 	script := gemini.GenerateDJScript(scriptCtx, gemini.DJScriptContext{
-		Type:          gemini.AnnouncementTransition,
-		CurrentSong:   current.Title,
-		NextSong:      next.Title,
-		RecentHistory: recentHistory,
-		IsRadioPick:   next.IsRadioPick,
+		Type:            gemini.AnnouncementTransition,
+		CurrentSong:     current.Title,
+		NextSong:        next.Title,
+		RecentHistory:   recentHistory,
+		IsRadioPick:     next.IsRadioPick,
+		CurrentQueuedBy: current.QueuedBy,
+		NextQueuedBy:    next.QueuedBy,
 	})
 	if script == "" {
 		return
@@ -2037,7 +2051,7 @@ func (p *GuildPlayer) playNoMoreSongsMessage() {
 		Type: gemini.AnnouncementQueueEmpty,
 	})
 	if script == "" {
-		script = "That's all for now. Queue up more with /queue, or turn on radio mode with /radio for non-stop tunes."
+		script = "That's all for now. Hit up /radio and I'll keep the vibes going based on what we've been playing. Or queue something specific with /play."
 	}
 
 	ttsPrompt := gemini.BuildTTSPrompt(script)

--- a/controller/playback_state.go
+++ b/controller/playback_state.go
@@ -12,6 +12,7 @@ type SongInfo struct {
 	Title       string
 	VideoID     string
 	IsRadioPick bool
+	QueuedBy    string // display name of user who queued, empty for radio picks
 }
 
 // PlaybackState is the authoritative single-source-of-truth for what is

--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -38,11 +38,13 @@ const (
 // DJScriptContext carries the situational details GenerateDJScript needs to
 // write a natural-sounding announcement for the given AnnouncementType.
 type DJScriptContext struct {
-	Type          AnnouncementType
-	CurrentSong   string   // song that just played (transition)
-	NextSong      string   // song coming up (transition, intro)
-	RecentHistory []string // recent song titles
-	IsRadioPick   bool     // whether next song was auto-queued by radio
+	Type            AnnouncementType
+	CurrentSong     string   // song that just played (transition)
+	NextSong        string   // song coming up (transition, intro)
+	RecentHistory   []string // recent song titles
+	IsRadioPick     bool     // whether next song was auto-queued by radio
+	CurrentQueuedBy string   // who queued the current song (empty = radio/unknown)
+	NextQueuedBy    string   // who queued the next song (empty = radio/unknown)
 }
 
 // Init initializes the shared Gemini client. Must be called once at startup
@@ -408,18 +410,27 @@ func GenerateDJScript(ctx context.Context, sc DJScriptContext) string {
 			radioStr = "This next song was auto-queued by radio mode based on the listening pattern."
 		}
 
+		requesterStr := ""
+		if sc.CurrentQueuedBy != "" {
+			requesterStr += fmt.Sprintf("The current song was queued by %s.\n", sc.CurrentQueuedBy)
+		}
+		if sc.NextQueuedBy != "" {
+			requesterStr += fmt.Sprintf("The next song was queued by %s.\n", sc.NextQueuedBy)
+		}
+
 		taskPrompt = fmt.Sprintf(`Current song (just finished): %s
 Next up: %s
 
 %s
 
 %s
-
+%s
 Your task: Announce what just played and what's coming up next. Write it as two halves: first announce what just played, then what's next.
 - You MUST say BOTH the song/artist that just played AND the song/artist coming up next
 - Never omit either name — they are the entire point of the announcement
+- If you know who queued a song, mention them by name. Skip attribution for songs with no requester.
 
-Now write your transition:`, sc.CurrentSong, sc.NextSong, recentHistoryBlock(sc.RecentHistory), radioStr)
+Now write your transition:`, sc.CurrentSong, sc.NextSong, recentHistoryBlock(sc.RecentHistory), radioStr, requesterStr)
 	case AnnouncementIntro:
 		taskPrompt = fmt.Sprintf(`First song of the session: %s
 
@@ -428,7 +439,7 @@ Your task: Introduce the first song of the session. Build a little anticipation 
 
 Now write your intro:`, sc.NextSong)
 	case AnnouncementQueueEmpty:
-		taskPrompt = `Your task: The queue just ran out. Let listeners know, and mention they can add songs with /queue or turn on non-stop music with /radio.
+		taskPrompt = `Your task: The queue just ran out. Hype up /radio mode as the way to keep the music going — it auto-queues songs based on what's been playing and it's awesome. Also mention /play or /queue for adding specific songs, but lead with radio as the main suggestion.
 
 Now write your announcement:`
 	default:

--- a/gemini/personality.go
+++ b/gemini/personality.go
@@ -21,17 +21,25 @@ When responding to music player commands (play, skip, pause, etc.):
 // TTSPersonalityPrompt is the DJ personality adapted for spoken word.
 // Used as the system prompt for the LLM that generates DJ scripts with audio tags.
 const TTSPersonalityPrompt = `You are beatbot, a DJ announcing between songs on a Discord music channel.
-Write what you'd actually SAY out loud. Natural, warm, confident. Not a
-morning show host, not monotone. The person at the party with impeccable
-taste who genuinely loves what's playing.
+Write what you'd actually SAY out loud. Cool, calm, collected. You sound
+like the person at the party who just knows music — not the one trying to
+get everyone hyped. Think college radio host, not morning zoo.
+
+Tone rules (critical):
+- Never use slang like "fam", "vibes", "banger", "slaps", "fire", "let's go",
+  "ready to get rocked", "strap in", or any phrase that sounds like a person
+  trying hard to sound young
+- No hype language. No exclamation energy. Understated always wins.
+- Talk like a real person with good taste, not a brand account
+- Simple, direct language. "Here's" over "coming your way". "That was" over
+  "we just rode out with"
 
 Use audio tags in square brackets to direct your delivery. Place them
 before the words they should color. Match the energy to the music:
 - [warm] — smooth, appreciative moments
-- [excited] — high-energy drops, bangers, hype moments
 - [smooth] — chill transitions, laid-back vibes
-- [laughs] — genuine amusement, playful moments
 - [chill] — relaxed, easy-going delivery
+- [excited] — reserved for genuinely high-energy moments only
 
 Rules:
 - 1-2 sentences, 15-25 words max
@@ -43,19 +51,17 @@ Rules:
 // TTSAudioProfile is the fixed audio profile that wraps every TTS call.
 // The %s placeholder is filled with the generated transcript.
 const TTSAudioProfile = `AUDIO PROFILE: beatbot / "The Booth"
-A warm, confident music lover who happens to be your DJ. Not a hype host.
-The person who puts on the perfect record and genuinely loves sharing it.
-When they speak between songs, you hear real appreciation for what just
-played and natural anticipation for what's next.
+Cool, calm, collected. A music lover who happens to be your DJ.
+Not a hype host. The person who just puts on the right record and
+lets it speak for itself. Understated and genuine.
 
 DIRECTOR'S NOTES:
-Style: Natural warmth with easy confidence. Not performing excitement,
-just letting it come through. Think late-night radio, the DJ who makes
-you feel like you're the only one listening. The "vocal smile" — you can
-hear the grin without it being forced.
-Pacing: Conversational flow. Not rushed, not dragging. Words breathe
-naturally, like talking to friends between songs. Slight emphasis on
-artist and song names.
+Style: Easy confidence without any performance. Think late-night
+college radio, not morning drive time. Relaxed, matter-of-fact,
+like someone mentioning a good song to a friend. Never sounds like
+they're selling anything or trying to get a crowd going.
+Pacing: Unhurried. Let words land naturally. No rush, no drag.
+Slight emphasis on artist and song names.
 
 TRANSCRIPT:
 %s`


### PR DESCRIPTION
## Summary

- **"Queued by" attribution**: Transition announcements now include who queued each song. The DJ says things like "That was Get Back, queued by Ben. Up next, Come Together, queued by Thomas." Radio picks skip attribution. Uses the existing `GetOrFetchUsername` pattern (guild nick > global name > "Unknown", 7-day SQLite cache).
- **Queue-empty hypes radio**: The "no more songs" announcement now leads with /radio as the primary suggestion ("Hit up /radio and I'll keep the vibes going") instead of treating it as an equal option alongside /queue.

## Changes

- `controller/playback_state.go`: Added `QueuedBy` field to `SongInfo`
- `gemini/gemini.go`: Added `CurrentQueuedBy`/`NextQueuedBy` to `DJScriptContext`, updated transition prompt with attribution rule, rewrote queue-empty prompt to lead with radio
- `controller/controller.go`: Added `resolveQueuedBy` helper, threaded through `syncNextFromQueue`, `PlaybackStarted`, and `generateTransitionTTS`

## Test plan

- [ ] Queue 2 songs as a user, verify DJ says "queued by [name]"
- [ ] Let radio auto-queue a song, verify DJ skips attribution for radio picks
- [ ] Let queue drain without radio, verify DJ hypes up /radio mode
- [ ] Verify no regressions on normal transitions