### PR TITLE
feat: radio mode joins voice and seeds history from DB

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1360,11 +1360,39 @@ func (p *GuildPlayer) ToggleRadio() bool {
 	enabled := p.RadioEnabled
 	p.radioMutex.Unlock()
 
-	if enabled && !p.Player.IsPlaying() && p.IsEmpty() && p.SongHistory.Len() > 0 {
-		go p.startRadioMode()
+	if enabled && !p.Player.IsPlaying() && p.IsEmpty() {
+		p.seedHistoryFromDB()
+		if p.SongHistory.Len() > 0 {
+			go p.startRadioMode()
+		}
 	}
 
 	return enabled
+}
+
+// seedHistoryFromDB loads recent plays from the SQLite song_history table
+// into the in-memory SongHistory ring buffer. Only runs when the buffer is
+// empty (e.g. fresh bot restart). This lets radio mode work immediately
+// without the user needing to queue songs first.
+func (p *GuildPlayer) seedHistoryFromDB() {
+	if p.SongHistory.Len() > 0 || p.DB == nil {
+		return
+	}
+	records, err := p.DB.GetHistory(p.GuildID, 10)
+	if err != nil {
+		log.Errorf("Failed to seed song history from DB: %v", err)
+		return
+	}
+	if len(records) == 0 {
+		return
+	}
+	for i := len(records) - 1; i >= 0; i-- {
+		p.SongHistory.Add(SongHistoryEntry{
+			VideoID: records[i].VideoID,
+			Title:   records[i].Title,
+		})
+	}
+	log.Debugf("Seeded song history from DB with %d entries for guild %s", len(records), p.GuildID)
 }
 
 // IsRadioEnabled returns whether radio mode is on

--- a/handlers/playback.go
+++ b/handlers/playback.go
@@ -148,7 +148,35 @@ func (manager *Manager) handleLoop(ctx context.Context, interaction *Interaction
 func (manager *Manager) handleRadio(ctx context.Context, interaction *Interaction) Response {
 	player := manager.Controller.GetPlayer(interaction.GuildID)
 
+	// Before toggling on, make sure the bot is in voice
+	// (peek at the current state to know if we're enabling)
+	wasEnabled := player.IsRadioEnabled()
+
 	enabled := player.ToggleRadio()
+
+	if enabled && !wasEnabled {
+		voiceState, _ := discord.GetMemberVoiceState(&interaction.Member.User.ID, &interaction.GuildID)
+		if voiceState == nil {
+			player.ToggleRadio() // undo
+			return Response{
+				Type: 4,
+				Data: ResponseData{
+					Content: "📻 Join a voice channel first, then try again.",
+				},
+			}
+		}
+		if player.ShouldJoinVoice(voiceState.ChannelID) {
+			if err := player.JoinVoiceChannel(interaction.Member.User.ID); err != nil {
+				player.ToggleRadio() // undo
+				return Response{
+					Type: 4,
+					Data: ResponseData{
+						Content: "📻 Couldn't join your voice channel: " + err.Error(),
+					},
+				}
+			}
+		}
+	}
 
 	// Generate DJ response with a tight deadline so we never blow Discord's 3s interaction limit
 	djCtx, djCancel := context.WithTimeout(ctx, 1500*time.Millisecond)
@@ -159,6 +187,9 @@ func (manager *Manager) handleRadio(ctx context.Context, interaction *Interactio
 	var msg string
 	if enabled {
 		msg = "📻 Radio mode **enabled** — " + djResponse
+		if player.SongHistory.Len() == 0 {
+			msg += "\n*Queue a few songs first so I have something to go off of.*"
+		}
 	} else {
 		msg = "📻 Radio mode **disabled** — " + djResponse
 	}


### PR DESCRIPTION
## Summary

- **Radio joins voice**: When `/radio` is enabled while the bot isn't in a voice channel, it now joins the user's channel first (same pattern as `/play`). If the user isn't in voice, the toggle is undone with "join a voice channel first."
- **Seeds history from DB**: On a fresh session, the in-memory `SongHistory` is empty but SQLite's `song_history` table has all past plays. `seedHistoryFromDB()` loads the last 10 plays so radio can pick songs immediately without the user needing to manually queue anything.
- **No-history hint**: If both in-memory and DB are truly empty (new guild), the response shows "Queue a few songs first so I have something to go off of."

## Test plan

- [ ] Fresh session, bot not in voice, guild has DB history: `/radio` joins voice, seeds history, queues pick, plays announcement
- [ ] Fresh session, truly empty guild: `/radio` joins voice, shows "queue a few songs" hint
- [ ] User not in any voice channel: `/radio` shows "join a voice channel first"
- [ ] Already in voice with history: `/radio` works as before