### PR TITLE
feat: default DJ announcements on, add /announce discoverability hints

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -308,8 +308,8 @@ func (c *Controller) GetPlayer(guildID string) *GuildPlayer {
 		playerCancel:         playerCancel,
 	}
 
-	// Load announce settings from DB
-	if val, _ := c.db.GetGuildSetting(guildID, "announce_enabled"); val == "true" {
+	// Load announce settings from DB — default to enabled; only disable when explicitly stored as "false"
+	if val, _ := c.db.GetGuildSetting(guildID, "announce_enabled"); val != "false" {
 		session.SetAnnounceEnabled(true)
 	}
 	if val, _ := c.db.GetGuildSetting(guildID, "announce_voice"); val != "" {
@@ -2274,8 +2274,14 @@ func (p *GuildPlayer) sendNowPlayingCard(queueItem *GuildQueueItem) {
 	// Build embed (no buttons - use commands instead)
 	embed := discord.BuildNowPlayingEmbed(metadata)
 
+	// Include a discoverable hint about /announce occasionally when DJ announcements are on
+	content := ""
+	if p.GetAnnounceEnabled() && rand.Float32() < 0.15 {
+		content = "-# 💡 Use /announce to disable DJ voice announcements"
+	}
+
 	// Send message
-	message, err := discord.SendChannelMessage(textCh, "", embed, nil)
+	message, err := discord.SendChannelMessage(textCh, content, embed, nil)
 	if err != nil {
 		log.Errorf("Failed to send now-playing card: %v", err)
 		if discord.IsMissingPermissions(err) {

--- a/handlers/hints.go
+++ b/handlers/hints.go
@@ -39,6 +39,7 @@ func NewHints() *Hints {
 			"Pro tip: /volume adjusts the playback volume (0-150)",
 			"Pro tip: /lyrics shows lyrics for the currently playing song",
 			"Pro tip: /favorite saves the current song to your favorites",
+			"Pro tip: /announce toggles the DJ voice announcements between songs",
 		},
 	}
 }


### PR DESCRIPTION
## Why

DJ voice announcements were opt-in (defaulted off), so new servers never heard the feature. This makes it on by default and surfaces the `/announce` command so users can find and disable it.

## What Changed

- `AnnounceEnabled` now defaults to `true` for new guilds — opt-out instead of opt-in (guilds that explicitly stored `"false"` are unaffected)
- Added `/announce toggles the DJ voice announcements between songs` to the random pro-tip pool
- `sendNowPlayingCard` shows a `-# 💡 Use /announce to disable DJ voice announcements` subtext hint with ~15% probability when announcements are active