### PR TITLE
feat: use YouTube Mix playlists for genre-accurate radio picks

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1559,8 +1559,34 @@ func (p *GuildPlayer) queueRadioSong() string {
 	var picked *youtube.VideoResponse
 	var videos []youtube.VideoResponse
 
-	// Try Gemini-powered recommendation first
-	if config.Config.Gemini.Enabled && len(recent) >= 3 {
+	// Try YouTube Mix playlist first — uses YouTube's own recommendation engine
+	// seeded from the most recently played video. Genre-accurate without relying
+	// on title-based AI inference (which confuses "Microwave" emo vs "Microwave" rap).
+	if seedHistory := p.SongHistory.GetRecent(1); len(seedHistory) > 0 && seedHistory[0].VideoID != "" {
+		seedVideoID := seedHistory[0].VideoID
+		logger.Debugf("Trying YouTube Mix playlist for seed video: %s", seedVideoID)
+
+		mixVideos, err := youtube.GetMixPlaylistVideos(ctx, seedVideoID)
+		if err != nil {
+			logger.Warnf("YouTube Mix playlist failed, falling through to Gemini: %v", err)
+		} else {
+			for i := range mixVideos {
+				if !historyIDs[mixVideos[i].VideoID] && !isRecentTitle(mixVideos[i].Title, recentTitles) {
+					picked = &mixVideos[i]
+					break
+				}
+			}
+			if picked != nil {
+				query = "youtube-mix:" + seedVideoID
+				logger.Infof("YouTube Mix picked: %s", picked.Title)
+			} else {
+				logger.Debug("YouTube Mix results were all duplicates, falling through to Gemini")
+			}
+		}
+	}
+
+	// Try Gemini-powered recommendation if YouTube Mix came up empty
+	if picked == nil && config.Config.Gemini.Enabled && len(recent) >= 3 {
 		// Extract song titles for Gemini
 		songTitles := make([]string, len(recent))
 		for i, song := range recent {

--- a/youtube/client.go
+++ b/youtube/client.go
@@ -217,6 +217,163 @@ func GetPlaylistVideos(ctx context.Context, playlistID string, limit int) (*Play
 	}, nil
 }
 
+// GetMixPlaylistVideos returns videos from YouTube's auto-generated "RD" Mix
+// playlist for seedVideoID, filtered to tracks under 12 minutes. It tries the
+// YouTube Data API first; if fewer than 3 results come back (dynamic mixes are
+// often not exposed via the API), it falls back to yt-dlp.
+func GetMixPlaylistVideos(ctx context.Context, seedVideoID string) ([]VideoResponse, error) {
+	logger := log.WithFields(log.Fields{
+		"module":   "youtube",
+		"function": "GetMixPlaylistVideos",
+		"seed_id":  seedVideoID,
+	})
+
+	span := sentry.StartSpan(ctx, "youtube.get_mix_playlist")
+	span.Description = "Fetch YouTube Mix playlist for radio"
+	span.SetTag("seed_video_id", seedVideoID)
+	defer span.Finish()
+
+	// Tier 1: YouTube Data API
+	apiResults, apiErr := fetchMixViaAPI(ctx, "RD"+seedVideoID, seedVideoID, logger)
+	if apiErr != nil {
+		logger.Debugf("Data API mix fetch failed: %v, falling back to yt-dlp", apiErr)
+	} else if len(apiResults) >= 3 {
+		span.Status = sentry.SpanStatusOK
+		span.SetData("source", "api")
+		span.SetData("count", len(apiResults))
+		return apiResults, nil
+	} else {
+		logger.Debugf("Data API returned %d mix results, falling back to yt-dlp", len(apiResults))
+	}
+
+	// Tier 2: yt-dlp
+	ytdlpResults, ytdlpErr := fetchMixViaYtdlp(ctx, seedVideoID, logger)
+	if ytdlpErr != nil {
+		span.Status = sentry.SpanStatusInternalError
+		if apiErr != nil {
+			return nil, fmt.Errorf("mix playlist failed: api: %v; yt-dlp: %v", apiErr, ytdlpErr)
+		}
+		return nil, fmt.Errorf("mix playlist yt-dlp failed (api returned %d results): %v", len(apiResults), ytdlpErr)
+	}
+
+	span.Status = sentry.SpanStatusOK
+	span.SetData("source", "yt-dlp")
+	span.SetData("count", len(ytdlpResults))
+	return ytdlpResults, nil
+}
+
+func fetchMixViaAPI(ctx context.Context, playlistID, seedVideoID string, logger *log.Entry) ([]VideoResponse, error) {
+	service, err := ytapi.NewService(ctx, option.WithAPIKey(config.Config.Youtube.APIKey))
+	if err != nil {
+		return nil, fmt.Errorf("creating YouTube client: %v", err)
+	}
+
+	itemsResp, err := service.PlaylistItems.List([]string{"snippet"}).
+		PlaylistId(playlistID).
+		MaxResults(25).
+		Do()
+	if err != nil {
+		return nil, fmt.Errorf("playlistItems.list: %v", err)
+	}
+
+	videoIDs := make([]string, 0, len(itemsResp.Items))
+	titleMap := make(map[string]string)
+	for _, item := range itemsResp.Items {
+		vid := item.Snippet.ResourceId.VideoId
+		if vid == "" || vid == seedVideoID {
+			continue
+		}
+		videoIDs = append(videoIDs, vid)
+		titleMap[vid] = html.UnescapeString(item.Snippet.Title)
+	}
+
+	if len(videoIDs) == 0 {
+		return nil, nil
+	}
+
+	detailsResp, err := service.Videos.List([]string{"contentDetails"}).Id(videoIDs...).Do()
+	if err != nil {
+		return nil, fmt.Errorf("videos.list: %v", err)
+	}
+
+	videos := make([]VideoResponse, 0, len(detailsResp.Items))
+	for _, item := range detailsResp.Items {
+		dur := parseYoutubeDuration(item.ContentDetails.Duration)
+		if dur > 0 && dur <= 12*time.Minute {
+			videos = append(videos, VideoResponse{
+				Title:    titleMap[item.Id],
+				VideoID:  item.Id,
+				Duration: dur,
+			})
+		}
+	}
+
+	return videos, nil
+}
+
+func fetchMixViaYtdlp(ctx context.Context, seedVideoID string, logger *log.Entry) ([]VideoResponse, error) {
+	mixURL := fmt.Sprintf("https://www.youtube.com/watch?v=%s&list=RD%s", seedVideoID, seedVideoID)
+
+	ytdlpCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ytdlpCtx,
+		"yt-dlp",
+		"--flat-playlist",
+		"--print", "%(id)s",
+		"--playlist-end", "25",
+		"--socket-timeout", "10",
+		"--no-warnings",
+		mixURL,
+	)
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("yt-dlp flat-playlist: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	videoIDs := make([]string, 0, len(lines))
+	for _, line := range lines {
+		id := strings.TrimSpace(line)
+		if id != "" && id != seedVideoID {
+			videoIDs = append(videoIDs, id)
+		}
+	}
+
+	if len(videoIDs) == 0 {
+		return nil, fmt.Errorf("yt-dlp returned no video IDs")
+	}
+
+	service, err := ytapi.NewService(ctx, option.WithAPIKey(config.Config.Youtube.APIKey))
+	if err != nil {
+		return nil, fmt.Errorf("creating YouTube client for yt-dlp IDs: %v", err)
+	}
+
+	detailsResp, err := service.Videos.List([]string{"snippet", "contentDetails"}).Id(videoIDs...).Do()
+	if err != nil {
+		return nil, fmt.Errorf("videos.list for yt-dlp IDs: %v", err)
+	}
+
+	videos := make([]VideoResponse, 0, len(detailsResp.Items))
+	for _, item := range detailsResp.Items {
+		dur := parseYoutubeDuration(item.ContentDetails.Duration)
+		if dur > 0 && dur <= 12*time.Minute {
+			videos = append(videos, VideoResponse{
+				Title:    html.UnescapeString(item.Snippet.Title),
+				VideoID:  item.Id,
+				Duration: dur,
+			})
+		}
+	}
+
+	if len(videos) == 0 {
+		return nil, fmt.Errorf("no tracks under 12 minutes in yt-dlp mix results")
+	}
+
+	return videos, nil
+}
+
 func Query(ctx context.Context, query string) []VideoResponse {
 	logger := log.WithFields(log.Fields{"module": "youtube", "function": "Query"})
 


### PR DESCRIPTION
## Summary

- Radio mode previously selected songs by passing recent song titles to Gemini, which had no musical context — a song called "Microwave" by an emo band would lead to a rap track with the same name being queued next
- YouTube auto-generates `RD{videoID}` mix playlists using their own recommendation engine (the same thing that powers YouTube Radio in-product), which are genre-accurate by construction
- `GetMixPlaylistVideos` tries the YouTube Data API first, falls back to `yt-dlp --flat-playlist` if the API returns fewer than 3 results (dynamic mixes are often not exposed via the API)
- The radio waterfall is now: YouTube Mix → Gemini → artist-name fallback

## Test Plan

- [ ] Enable radio mode, play a song with an ambiguous title (e.g. "Microwave" by Microwave), confirm the next auto-queued pick is genre-adjacent (post-hardcore/emo) not name-adjacent (rap)
- [ ] Let radio run 5+ songs, confirm no repeats
- [ ] Check logs/Sentry spans for `youtube.get_mix_playlist` — confirm `source: api` or `source: yt-dlp` and that fallback fires when expected
- [ ] Confirm `go build` and `go test ./...` pass