### PR TITLE
fix: stop now-playing ticker on idle disconnect and voice recovery failure

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1329,6 +1329,11 @@ func (p *GuildPlayer) startIdleChecker() {
 						p.Player.Stop()
 					}
 
+					// Player.Stop() does not emit PlaybackStopped, so the
+					// now-playing ticker won't self-terminate. Stop it explicitly.
+					p.stopNowPlayingUpdates()
+					p.clearNowPlayingCard()
+
 					// Stop voice monitoring before cleanup
 					p.stopVoiceConnectionMonitor()
 
@@ -2067,6 +2072,9 @@ func (p *GuildPlayer) handleVoiceRecoveryFailure() {
 	if p.Player != nil {
 		p.Player.Stop()
 	}
+
+	p.stopNowPlayingUpdates()
+	p.clearNowPlayingCard()
 
 	p.VoiceChannelMutex.Lock()
 	p.VoiceConnection = nil


### PR DESCRIPTION
## Why
After idle timeout, `Player.Stop()` exits `Play()` with nil without emitting `PlaybackStopped`, so `listenForPlaybackEvents` never called `stopNowPlayingUpdates()`. The 2-second edit ticker kept running indefinitely until Discord rejected edits with code 30046 ("Maximum number of edits to messages older than 1 hour").

## What Changed
Added explicit `stopNowPlayingUpdates()` + `clearNowPlayingCard()` calls in `startIdleChecker()` and `handleVoiceRecoveryFailure()` — both paths call `Player.Stop()` without a subsequent `playNext()` that would otherwise stop the ticker via `startNowPlayingUpdates()`.