### PR TITLE
feat: /request command and themed radio mode

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -122,7 +122,28 @@
   {
     "name": "radio",
     "type": 1,
-    "description": "Toggle radio mode - automatically queues similar songs when the queue is empty"
+    "description": "Toggle radio mode - automatically queues similar songs. Add a vibe to guide the picks.",
+    "options": [
+      {
+        "name": "vibe",
+        "description": "A mood, artist, or genre to guide radio picks (e.g. 'chill indie', '90s hip hop')",
+        "type": 3,
+        "required": false
+      }
+    ]
+  },
+  {
+    "name": "request",
+    "type": 1,
+    "description": "Ask the DJ to rework the queue with a suggestion",
+    "options": [
+      {
+        "name": "suggestion",
+        "description": "What you want to hear (e.g. 'something chill', 'more punk', 'Radiohead deep cuts')",
+        "type": 3,
+        "required": true
+      }
+    ]
   },
   {
     "name": "loop",

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -122,6 +122,7 @@ type GuildPlayer struct {
 	loadListenerStop       chan struct{}
 	ttsWatcherStop         chan struct{}
 	RadioEnabled           bool
+	RadioTheme             string // user-provided vibe for radio picks, empty = history-based
 	radioMutex             sync.Mutex
 	radioQueueing          sync.Mutex // held while queueRadioSong is in-flight, prevents double-queue
 	radioStartAnnouncement *audio.TTSPlayback
@@ -1407,6 +1408,27 @@ func (p *GuildPlayer) IsRadioEnabled() bool {
 	return p.RadioEnabled
 }
 
+// SetRadioTheme sets a user-provided vibe/theme for radio song picking.
+func (p *GuildPlayer) SetRadioTheme(theme string) {
+	p.radioMutex.Lock()
+	defer p.radioMutex.Unlock()
+	p.RadioTheme = theme
+}
+
+// GetRadioTheme returns the current radio theme, empty if unset.
+func (p *GuildPlayer) GetRadioTheme() string {
+	p.radioMutex.Lock()
+	defer p.radioMutex.Unlock()
+	return p.RadioTheme
+}
+
+// ClearRadioTheme resets radio picking back to history-based mode.
+func (p *GuildPlayer) ClearRadioTheme() {
+	p.radioMutex.Lock()
+	defer p.radioMutex.Unlock()
+	p.RadioTheme = ""
+}
+
 func (p *GuildPlayer) ToggleLoop() bool {
 	p.loopMutex.Lock()
 	defer p.loopMutex.Unlock()
@@ -1559,102 +1581,163 @@ func (p *GuildPlayer) pickRadioSong() *youtube.VideoResponse {
 	var picked *youtube.VideoResponse
 	var videos []youtube.VideoResponse
 
-	// Try YouTube Mix playlist first — uses YouTube's own recommendation engine
-	// seeded from the most recently played video. Genre-accurate without relying
-	// on title-based AI inference (which confuses "Microwave" emo vs "Microwave" rap).
-	if seedHistory := p.SongHistory.GetRecent(1); len(seedHistory) > 0 && seedHistory[0].VideoID != "" {
-		seedVideoID := seedHistory[0].VideoID
-		logger.Debugf("Trying YouTube Mix playlist for seed video: %s", seedVideoID)
+	theme := p.GetRadioTheme()
 
-		mixVideos, err := youtube.GetMixPlaylistVideos(ctx, seedVideoID)
-		if err != nil {
-			logger.Warnf("YouTube Mix playlist failed, falling through to Gemini: %v", err)
-		} else {
-			for i := range mixVideos {
-				if !historyIDs[mixVideos[i].VideoID] && !isRecentTitle(mixVideos[i].Title, recentTitles) {
-					picked = &mixVideos[i]
+	if theme != "" {
+		// Themed mode: YouTube Mix doesn't understand arbitrary vibes, so skip
+		// it entirely and go straight to Gemini with the user-provided theme.
+		if config.Config.Gemini.Enabled && len(recent) > 0 {
+			songTitles := make([]string, len(recent))
+			for i, song := range recent {
+				songTitles[i] = song.Title
+			}
+
+			logger.Debugf("Requesting themed Gemini song recommendation for theme: %s", theme)
+			query = gemini.GenerateThemedRecommendation(ctx, theme, songTitles)
+
+			if query != "" {
+				logger.Infof("Gemini recommended themed search query: %s", query)
+
+				sentry.AddBreadcrumb(&sentry.Breadcrumb{
+					Category: "radio",
+					Message:  "Gemini generated themed recommendation query",
+					Level:    sentry.LevelInfo,
+					Data: map[string]interface{}{
+						"guild_id": p.GuildID,
+						"theme":    theme,
+						"query":    query,
+					},
+				})
+
+				videos = youtube.Query(ctx, query)
+				if len(videos) > 0 {
+					for i := range videos {
+						if !historyIDs[videos[i].VideoID] && !isRecentTitle(videos[i].Title, recentTitles) {
+							picked = &videos[i]
+							break
+						}
+					}
+				}
+			} else {
+				logger.Warn("Gemini themed recommendation returned empty query, falling back to direct theme search")
+			}
+		}
+
+		// Themed fallback: search YouTube directly with the theme string.
+		if picked == nil {
+			logger.Debugf("Searching YouTube directly for theme: %s", theme)
+
+			videos = youtube.Query(ctx, theme)
+			if len(videos) == 0 {
+				logger.Warn("radio: no YouTube results found for theme")
+				return nil
+			}
+
+			for i := range videos {
+				if !historyIDs[videos[i].VideoID] && !isRecentTitle(videos[i].Title, recentTitles) {
+					picked = &videos[i]
 					break
 				}
 			}
-			if picked != nil {
-				query = "youtube-mix:" + seedVideoID
-				logger.Infof("YouTube Mix picked: %s", picked.Title)
+		}
+	} else {
+		// Try YouTube Mix playlist first — uses YouTube's own recommendation engine
+		// seeded from the most recently played video. Genre-accurate without relying
+		// on title-based AI inference (which confuses "Microwave" emo vs "Microwave" rap).
+		if seedHistory := p.SongHistory.GetRecent(1); len(seedHistory) > 0 && seedHistory[0].VideoID != "" {
+			seedVideoID := seedHistory[0].VideoID
+			logger.Debugf("Trying YouTube Mix playlist for seed video: %s", seedVideoID)
+
+			mixVideos, err := youtube.GetMixPlaylistVideos(ctx, seedVideoID)
+			if err != nil {
+				logger.Warnf("YouTube Mix playlist failed, falling through to Gemini: %v", err)
 			} else {
-				logger.Debug("YouTube Mix results were all duplicates, falling through to Gemini")
+				for i := range mixVideos {
+					if !historyIDs[mixVideos[i].VideoID] && !isRecentTitle(mixVideos[i].Title, recentTitles) {
+						picked = &mixVideos[i]
+						break
+					}
+				}
+				if picked != nil {
+					query = "youtube-mix:" + seedVideoID
+					logger.Infof("YouTube Mix picked: %s", picked.Title)
+				} else {
+					logger.Debug("YouTube Mix results were all duplicates, falling through to Gemini")
+				}
 			}
 		}
-	}
 
-	// Try Gemini-powered recommendation if YouTube Mix came up empty
-	if picked == nil && config.Config.Gemini.Enabled && len(recent) >= 3 {
-		songTitles := make([]string, len(recent))
-		for i, song := range recent {
-			songTitles[i] = song.Title
+		// Try Gemini-powered recommendation if YouTube Mix came up empty
+		if picked == nil && config.Config.Gemini.Enabled && len(recent) >= 3 {
+			songTitles := make([]string, len(recent))
+			for i, song := range recent {
+				songTitles[i] = song.Title
+			}
+
+			logger.Debug("Requesting Gemini song recommendation based on recent history")
+			query = gemini.GenerateSongRecommendation(ctx, songTitles)
+
+			if query != "" {
+				logger.Infof("Gemini recommended search query: %s", query)
+
+				sentry.AddBreadcrumb(&sentry.Breadcrumb{
+					Category: "radio",
+					Message:  "Gemini generated recommendation query",
+					Level:    sentry.LevelInfo,
+					Data: map[string]interface{}{
+						"guild_id": p.GuildID,
+						"query":    query,
+					},
+				})
+
+				videos = youtube.Query(ctx, query)
+				if len(videos) > 0 {
+					for i := range videos {
+						if !historyIDs[videos[i].VideoID] && !isRecentTitle(videos[i].Title, recentTitles) {
+							picked = &videos[i]
+							break
+						}
+					}
+				}
+			} else {
+				logger.Warn("Gemini recommendation returned empty query, falling back to legacy method")
+			}
 		}
 
-		logger.Debug("Requesting Gemini song recommendation based on recent history")
-		query = gemini.GenerateSongRecommendation(ctx, songTitles)
+		if picked == nil {
+			logger.Debug("Using fallback legacy search method")
 
-		if query != "" {
-			logger.Infof("Gemini recommended search query: %s", query)
+			idx := rand.Intn(len(recent))
+			artist := ExtractArtist(recent[idx].Title)
+			query = artist + " music"
 
-			sentry.AddBreadcrumb(&sentry.Breadcrumb{
-				Category: "radio",
-				Message:  "Gemini generated recommendation query",
-				Level:    sentry.LevelInfo,
-				Data: map[string]interface{}{
-					"guild_id": p.GuildID,
-					"query":    query,
-				},
-			})
+			logger.Infof("Radio searching for: %s", query)
 
 			videos = youtube.Query(ctx, query)
-			if len(videos) > 0 {
+			if len(videos) == 0 {
+				logger.Warn("radio: no YouTube results found")
+				return nil
+			}
+
+			for i := range videos {
+				if !historyIDs[videos[i].VideoID] && !isRecentTitle(videos[i].Title, recentTitles) {
+					picked = &videos[i]
+					break
+				}
+			}
+
+			if picked == nil {
+				logger.Info("radio: all search results already in history, trying broader query")
+				fallbackIdx := (idx + 1) % len(recent)
+				fallbackArtist := ExtractArtist(recent[fallbackIdx].Title)
+				fallbackQuery := fallbackArtist + " songs"
+
+				videos = youtube.Query(ctx, fallbackQuery)
 				for i := range videos {
 					if !historyIDs[videos[i].VideoID] && !isRecentTitle(videos[i].Title, recentTitles) {
 						picked = &videos[i]
 						break
 					}
-				}
-			}
-		} else {
-			logger.Warn("Gemini recommendation returned empty query, falling back to legacy method")
-		}
-	}
-
-	if picked == nil {
-		logger.Debug("Using fallback legacy search method")
-
-		idx := rand.Intn(len(recent))
-		artist := ExtractArtist(recent[idx].Title)
-		query = artist + " music"
-
-		logger.Infof("Radio searching for: %s", query)
-
-		videos = youtube.Query(ctx, query)
-		if len(videos) == 0 {
-			logger.Warn("radio: no YouTube results found")
-			return nil
-		}
-
-		for i := range videos {
-			if !historyIDs[videos[i].VideoID] && !isRecentTitle(videos[i].Title, recentTitles) {
-				picked = &videos[i]
-				break
-			}
-		}
-
-		if picked == nil {
-			logger.Info("radio: all search results already in history, trying broader query")
-			fallbackIdx := (idx + 1) % len(recent)
-			fallbackArtist := ExtractArtist(recent[fallbackIdx].Title)
-			fallbackQuery := fallbackArtist + " songs"
-
-			videos = youtube.Query(ctx, fallbackQuery)
-			for i := range videos {
-				if !historyIDs[videos[i].VideoID] && !isRecentTitle(videos[i].Title, recentTitles) {
-					picked = &videos[i]
-					break
 				}
 			}
 		}

--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -3,6 +3,7 @@ package gemini
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"beatbot/config"
@@ -11,6 +12,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/genai"
 )
+
+var leadingNumberRe = regexp.MustCompile(`^\d+\.\s*`)
 
 // defaultClient is the package-level Gemini client, initialized once by Init().
 // Creating a new HTTP client + TLS session on every call was wasteful.
@@ -357,6 +360,7 @@ Suggest 3-5 songs that match the request. Return each as a YouTube search query 
 	for _, line := range lines {
 		query := strings.TrimSpace(line)
 		query = strings.Trim(query, "\"'`")
+		query = leadingNumberRe.ReplaceAllString(query, "")
 		if query == "" {
 			continue
 		}

--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -270,6 +270,111 @@ Now generate your recommendation:`, songList))
 	return query
 }
 
+// GenerateThemedRecommendation is like GenerateSongRecommendation but driven primarily
+// by a user-provided theme (e.g. "chill indie", "90s hip hop", "Radiohead deep cuts"),
+// with recent song history as secondary context. Returns an empty string if Gemini is
+// disabled or on error.
+func GenerateThemedRecommendation(ctx context.Context, theme string, recentSongs []string) string {
+	if !config.Config.Gemini.Enabled || defaultClient == nil {
+		return ""
+	}
+
+	// Start span for Gemini themed recommendation generation
+	span := sentry.StartSpan(ctx, "gemini.themed_recommendation")
+	span.Description = "Generate themed song recommendation query"
+	span.SetTag("model", config.Config.Gemini.Model)
+	defer span.Finish()
+
+	songList := "No recent songs played yet."
+	if len(recentSongs) > 0 {
+		songList = strings.Join(recentSongs, "\n")
+	}
+
+	instructions := buildPrompt(fmt.Sprintf(`The listener wants: %s
+
+Their recent songs for context:
+%s
+
+Suggest ONE song that matches the requested vibe. Return ONLY a YouTube search query like "Artist - Song Title". Don't repeat anything from the list.`, theme, songList))
+
+	response := generateResponse(ctx, instructions)
+	if response == "" {
+		span.Status = sentry.SpanStatusInternalError
+		return ""
+	}
+
+	// Clean up the response (remove any extra formatting or explanations)
+	query := strings.TrimSpace(response)
+	// Remove quotes if present
+	query = strings.Trim(query, "\"'`")
+
+	span.Status = sentry.SpanStatusOK
+	span.SetData("query", query)
+
+	log.WithFields(log.Fields{
+		"module": "gemini",
+		"theme":  theme,
+		"query":  query,
+	}).Debug("Generated themed recommendation query")
+
+	return query
+}
+
+// GenerateRequestQueries generates 3-5 YouTube search queries matching a user's
+// free-text song/artist/vibe request, used by the /request command. Returns nil
+// if Gemini is disabled or on error.
+func GenerateRequestQueries(ctx context.Context, suggestion string, recentSongs []string) []string {
+	if !config.Config.Gemini.Enabled || defaultClient == nil {
+		return nil
+	}
+
+	// Start span for Gemini request query generation
+	span := sentry.StartSpan(ctx, "gemini.request_queries")
+	span.Description = "Generate request search queries"
+	span.SetTag("model", config.Config.Gemini.Model)
+	defer span.Finish()
+
+	songList := "No recent songs played yet."
+	if len(recentSongs) > 0 {
+		songList = strings.Join(recentSongs, "\n")
+	}
+
+	instructions := buildPrompt(fmt.Sprintf(`The listener is requesting: %s
+
+Their recent songs for context:
+%s
+
+Suggest 3-5 songs that match the request. Return each as a YouTube search query (e.g. "Artist - Song Title"), one per line. Don't repeat anything from the list. Don't number the lines.`, suggestion, songList))
+
+	response := generateResponse(ctx, instructions)
+	if response == "" {
+		span.Status = sentry.SpanStatusInternalError
+		return nil
+	}
+
+	lines := strings.Split(response, "\n")
+	queries := make([]string, 0, len(lines))
+	for _, line := range lines {
+		query := strings.TrimSpace(line)
+		query = strings.Trim(query, "\"'`")
+		if query == "" {
+			continue
+		}
+		queries = append(queries, query)
+	}
+
+	span.Status = sentry.SpanStatusOK
+	span.SetData("num_queries", fmt.Sprintf("%d", len(queries)))
+
+	log.WithFields(log.Fields{
+		"module":     "gemini",
+		"suggestion": suggestion,
+		"queries":    queries,
+	}).Debug("Generated request search queries")
+
+	return queries
+}
+
 // GenerateNowPlayingCommentary creates conversational DJ commentary for the current song
 // based on the song history and whether it was auto-queued by radio mode.
 func GenerateNowPlayingCommentary(ctx context.Context, currentSong string, recentHistory []string, isRadioPick bool) string {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -259,6 +259,10 @@ func (manager *Manager) HandleInteraction(interaction *Interaction) (response Re
 		finishTransaction = false
 		go manager.handleRecommend(ctx, transaction, interaction)
 		return Response{Type: 5}
+	case "request":
+		finishTransaction = false
+		go manager.handleRequest(ctx, transaction, interaction)
+		return Response{Type: 5}
 	case "favorite":
 		return manager.handleFavorite(interaction)
 	case "favorites":

--- a/handlers/hints.go
+++ b/handlers/hints.go
@@ -40,6 +40,7 @@ func NewHints() *Hints {
 			"Pro tip: /lyrics shows lyrics for the currently playing song",
 			"Pro tip: /favorite saves the current song to your favorites",
 			"Pro tip: /announce toggles the DJ voice announcements between songs",
+			"Pro tip: Use /request to tell the DJ what vibe you're going for",
 		},
 	}
 }

--- a/handlers/playback.go
+++ b/handlers/playback.go
@@ -15,6 +15,7 @@ import (
 	"beatbot/gemini"
 	"beatbot/helpers"
 	"beatbot/sentryhelper"
+	"beatbot/youtube"
 
 	"github.com/bwmarrin/discordgo"
 	"gopkg.in/hraban/opus.v2"
@@ -148,16 +149,40 @@ func (manager *Manager) handleLoop(ctx context.Context, interaction *Interaction
 func (manager *Manager) handleRadio(ctx context.Context, interaction *Interaction) Response {
 	player := manager.Controller.GetPlayer(interaction.GuildID)
 
-	// Before toggling on, make sure the bot is in voice
-	// (peek at the current state to know if we're enabling)
+	var vibe string
+	for _, opt := range interaction.Data.Options {
+		if opt.Name == "vibe" {
+			vibe = strings.TrimSpace(opt.Value)
+			break
+		}
+	}
+
 	wasEnabled := player.IsRadioEnabled()
 
-	enabled := player.ToggleRadio()
+	var enabled bool
+	if vibe != "" {
+		// A vibe was supplied: always turn radio on (never toggle off) and steer it.
+		enabled = true
+		if !wasEnabled {
+			player.ToggleRadio()
+		}
+		player.SetRadioTheme(vibe)
+	} else if wasEnabled {
+		// No vibe, radio already on: toggle off and drop any theme.
+		enabled = player.ToggleRadio()
+		player.ClearRadioTheme()
+	} else {
+		// No vibe, radio off: enable with plain history-based picking.
+		enabled = player.ToggleRadio()
+	}
 
-	if enabled && !wasEnabled {
+	if enabled {
 		voiceState, _ := discord.GetMemberVoiceState(&interaction.Member.User.ID, &interaction.GuildID)
 		if voiceState == nil {
-			player.ToggleRadio() // undo
+			if !wasEnabled {
+				player.ToggleRadio() // undo
+			}
+			player.ClearRadioTheme()
 			return Response{
 				Type: 4,
 				Data: ResponseData{
@@ -167,7 +192,10 @@ func (manager *Manager) handleRadio(ctx context.Context, interaction *Interactio
 		}
 		if player.ShouldJoinVoice(voiceState.ChannelID) {
 			if err := player.JoinVoiceChannel(interaction.Member.User.ID); err != nil {
-				player.ToggleRadio() // undo
+				if !wasEnabled {
+					player.ToggleRadio() // undo
+				}
+				player.ClearRadioTheme()
 				return Response{
 					Type: 4,
 					Data: ResponseData{
@@ -186,8 +214,13 @@ func (manager *Manager) handleRadio(ctx context.Context, interaction *Interactio
 
 	var msg string
 	if enabled {
-		msg = "📻 Radio mode **enabled** — " + djResponse
-		if player.SongHistory.Len() == 0 {
+		theme := player.GetRadioTheme()
+		if theme != "" {
+			msg = fmt.Sprintf("📻 Radio mode **enabled** — vibing to *%s* — %s", theme, djResponse)
+		} else {
+			msg = "📻 Radio mode **enabled** — " + djResponse
+		}
+		if player.SongHistory.Len() == 0 && theme == "" {
 			msg += "\n*Queue a few songs first so I have something to go off of.*"
 		}
 	} else {
@@ -200,6 +233,110 @@ func (manager *Manager) handleRadio(ctx context.Context, interaction *Interactio
 			Content: msg + hint,
 		},
 	}
+}
+
+func (manager *Manager) handleRequest(ctx context.Context, transaction *sentry.Span, interaction *Interaction) {
+	defer func() {
+		if err := recover(); err != nil {
+			sentryhelper.CaptureException(ctx, fmt.Errorf("panic in handleRequest: %v", err))
+			transaction.Status = sentry.SpanStatusInternalError
+		}
+		transaction.Finish()
+	}()
+
+	var suggestion string
+	for _, opt := range interaction.Data.Options {
+		if opt.Name == "suggestion" {
+			suggestion = strings.TrimSpace(opt.Value)
+			break
+		}
+	}
+	if suggestion == "" {
+		manager.SendFollowup(ctx, interaction, "", "Tell me what you want to hear! 🎵", true)
+		return
+	}
+
+	voiceState, err := discord.GetMemberVoiceState(&interaction.Member.User.ID, &interaction.GuildID)
+	if err != nil {
+		log.Errorf("Error getting voice state: %v", err)
+		sentryhelper.CaptureException(ctx, err)
+		manager.SendError(interaction, "Error getting voice state: "+err.Error(), true)
+		return
+	}
+	if voiceState == nil {
+		manager.SendFollowup(ctx, interaction, "", "Join a voice channel first! 🎤", true)
+		return
+	}
+
+	player := manager.Controller.GetPlayer(interaction.GuildID)
+	if player.ShouldJoinVoice(voiceState.ChannelID) {
+		if err := player.JoinVoiceChannel(interaction.Member.User.ID); err != nil {
+			errStr := err.Error()
+			if errStr == "voice state not found" {
+				manager.SendFollowup(ctx, interaction, "", "You gotta join a voice channel first!", true)
+				return
+			}
+			sentryhelper.CaptureException(ctx, err)
+			manager.SendError(interaction, "Error joining voice channel: "+errStr, true)
+			return
+		}
+	}
+
+	// Get recent history for context
+	recentEntries := player.SongHistory.GetRecent(5)
+	recentSongs := make([]string, len(recentEntries))
+	for i, e := range recentEntries {
+		recentSongs[i] = e.Title
+	}
+
+	// Generate search queries via Gemini
+	queries := gemini.GenerateRequestQueries(ctx, suggestion, recentSongs)
+	if len(queries) == 0 {
+		manager.SendFollowup(ctx, interaction, "", "Couldn't come up with anything for that. Try a different suggestion? 🤔", true)
+		return
+	}
+
+	// Clear existing queue
+	player.Clear()
+
+	// Search YouTube and queue each result
+	var queued []string
+	historyIDs := player.SongHistory.GetAllVideoIDs()
+	for _, query := range queries {
+		videos := youtube.Query(ctx, query)
+		if len(videos) == 0 {
+			continue
+		}
+		// Pick first non-duplicate
+		for _, v := range videos {
+			if !historyIDs[v.VideoID] {
+				player.Add(ctx, v, interaction.Member.User.ID, interaction.Token, manager.AppID, nil)
+				queued = append(queued, v.Title)
+				historyIDs[v.VideoID] = true // prevent dupes within this batch
+				break
+			}
+		}
+	}
+
+	if len(queued) == 0 {
+		manager.SendFollowup(ctx, interaction, "", "Found nothing good for that. Try something else? 🎵", true)
+		return
+	}
+
+	// Set radio theme and enable radio so it keeps steering picks after the queue drains
+	player.SetRadioTheme(suggestion)
+	if !player.IsRadioEnabled() {
+		player.ToggleRadio()
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("🎧 **DJ Request:** *%s*\n\n", suggestion))
+	for i, title := range queued {
+		sb.WriteString(fmt.Sprintf("%d. **%s**\n", i+1, title))
+	}
+	sb.WriteString("\n📻 Radio mode set to this vibe — I'll keep it going.")
+
+	manager.SendFollowup(ctx, interaction, "", sb.String(), false)
 }
 
 func (manager *Manager) handleAnnounce(ctx context.Context, interaction *Interaction) Response {

--- a/handlers/playback.go
+++ b/handlers/playback.go
@@ -158,21 +158,19 @@ func (manager *Manager) handleRadio(ctx context.Context, interaction *Interactio
 	}
 
 	wasEnabled := player.IsRadioEnabled()
+	oldTheme := player.GetRadioTheme()
 
 	var enabled bool
 	if vibe != "" {
-		// A vibe was supplied: always turn radio on (never toggle off) and steer it.
 		enabled = true
 		if !wasEnabled {
 			player.ToggleRadio()
 		}
 		player.SetRadioTheme(vibe)
 	} else if wasEnabled {
-		// No vibe, radio already on: toggle off and drop any theme.
 		enabled = player.ToggleRadio()
 		player.ClearRadioTheme()
 	} else {
-		// No vibe, radio off: enable with plain history-based picking.
 		enabled = player.ToggleRadio()
 	}
 
@@ -180,9 +178,9 @@ func (manager *Manager) handleRadio(ctx context.Context, interaction *Interactio
 		voiceState, _ := discord.GetMemberVoiceState(&interaction.Member.User.ID, &interaction.GuildID)
 		if voiceState == nil {
 			if !wasEnabled {
-				player.ToggleRadio() // undo
+				player.ToggleRadio()
 			}
-			player.ClearRadioTheme()
+			player.SetRadioTheme(oldTheme) // restore previous theme, not blank
 			return Response{
 				Type: 4,
 				Data: ResponseData{
@@ -193,9 +191,9 @@ func (manager *Manager) handleRadio(ctx context.Context, interaction *Interactio
 		if player.ShouldJoinVoice(voiceState.ChannelID) {
 			if err := player.JoinVoiceChannel(interaction.Member.User.ID); err != nil {
 				if !wasEnabled {
-					player.ToggleRadio() // undo
+					player.ToggleRadio()
 				}
-				player.ClearRadioTheme()
+				player.SetRadioTheme(oldTheme) // restore previous theme, not blank
 				return Response{
 					Type: 4,
 					Data: ResponseData{
@@ -296,31 +294,38 @@ func (manager *Manager) handleRequest(ctx context.Context, transaction *sentry.S
 		return
 	}
 
-	// Clear existing queue
-	player.Clear()
-
-	// Search YouTube and queue each result
-	var queued []string
+	// Search YouTube and collect results BEFORE clearing the queue,
+	// so the user doesn't end up with an empty queue if all searches fail.
+	type pickedVideo struct {
+		video youtube.VideoResponse
+	}
+	var picks []pickedVideo
 	historyIDs := player.SongHistory.GetAllVideoIDs()
 	for _, query := range queries {
 		videos := youtube.Query(ctx, query)
 		if len(videos) == 0 {
 			continue
 		}
-		// Pick first non-duplicate
 		for _, v := range videos {
 			if !historyIDs[v.VideoID] {
-				player.Add(ctx, v, interaction.Member.User.ID, interaction.Token, manager.AppID, nil)
-				queued = append(queued, v.Title)
-				historyIDs[v.VideoID] = true // prevent dupes within this batch
+				picks = append(picks, pickedVideo{video: v})
+				historyIDs[v.VideoID] = true
 				break
 			}
 		}
 	}
 
-	if len(queued) == 0 {
+	if len(picks) == 0 {
 		manager.SendFollowup(ctx, interaction, "", "Found nothing good for that. Try something else? 🎵", true)
 		return
+	}
+
+	// Now that we have confirmed results, clear the queue and add them.
+	player.Clear()
+	var queued []string
+	for _, p := range picks {
+		player.Add(ctx, p.video, interaction.Member.User.ID, interaction.Token, manager.AppID, nil)
+		queued = append(queued, p.video.Title)
 	}
 
 	// Set radio theme and enable radio so it keeps steering picks after the queue drains


### PR DESCRIPTION
## Summary

Two new features that let users guide what the DJ plays:

### `/request` command
Ask the DJ to rework the queue: `/request something chill and acoustic`. Clears the current queue, uses Gemini to generate 3-5 YouTube search queries matching the suggestion, queues the results, and sets the radio theme to continue in that vibe.

### Themed `/radio`
`/radio chill indie` enables radio biased toward that theme. Bare `/radio` toggles off. When a theme is set, radio skips YouTube Mix (which doesn't understand arbitrary themes) and goes straight to Gemini with the theme as the primary driver.

## Changes

- **`commands.json`**: Added optional `vibe` param to `/radio`, added `/request` with required `suggestion` param
- **`gemini/gemini.go`**: Added `GenerateThemedRecommendation` (single song, theme-driven) and `GenerateRequestQueries` (3-5 songs batch)
- **`controller/controller.go`**: Added `RadioTheme` field + getter/setter, modified `pickRadioSong` to branch on theme (skip YouTube Mix, use Gemini with theme context, fallback to direct theme search)
- **`handlers/playback.go`**: Updated `handleRadio` for vibe param, added `handleRequest` (deferred/async)
- **`handlers/handlers.go`**: Routed `/request` as async command
- **`handlers/hints.go`**: Added hint about `/request`

## Test plan

- [ ] `/radio chill indie`: enables radio, picks songs matching theme
- [ ] `/radio`: toggles off, clears theme
- [ ] `/radio 90s hip hop` while already on: updates theme, keeps radio on
- [ ] `/request Radiohead deep cuts`: clears queue, queues 3-5 matching songs, sets radio theme
- [ ] After `/request`, radio continues in the same vibe
- [ ] Normal radio (no theme): still works via YouTube Mix -> Gemini -> legacy