### PR TITLE
fix: skip redundant TTS regeneration when queued song isn't next

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -2199,11 +2199,18 @@ func (p *GuildPlayer) resolveQueuedBy(item *GuildQueueItem) string {
 func (p *GuildPlayer) syncNextFromQueue() {
 	next := p.GetNext()
 	if next != nil {
+		currentNext := p.playbackState.Next()
+		queuedBy := p.resolveQueuedBy(next)
+		if currentNext != nil && currentNext.VideoID == next.Video.VideoID &&
+			currentNext.IsRadioPick == next.IsRadioPick &&
+			currentNext.QueuedBy == queuedBy {
+			return
+		}
 		p.playbackState.SetNext(&SongInfo{
 			Title:       next.Video.Title,
 			VideoID:     next.Video.VideoID,
 			IsRadioPick: next.IsRadioPick,
-			QueuedBy:    p.resolveQueuedBy(next),
+			QueuedBy:    queuedBy,
 		})
 	} else {
 		p.playbackState.ClearNext()


### PR DESCRIPTION
## Why

Adding a song to the queue while another is playing triggers `syncNextFromQueue()`, which unconditionally calls `SetNext()`. That wipes the already-generated TTS buffer and triggers a redundant Gemini TTS API call, even when the next song hasn't changed (e.g., queuing at position 2+).

## What Changed

Added a guard in `syncNextFromQueue()` that compares the incoming queue head against what's already stored in PlaybackState (VideoID, IsRadioPick, QueuedBy). If all fields match, it returns early without clearing the TTS buffer or signaling regeneration. This matches the pattern already used in `RemoveFromQueue()`.