### PR TITLE
chore: upgrade Go from 1.25.0 to 1.26.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.26'
+        go-version: '1.26.5'
     - uses: actions/cache@v4
       with:
         path: |
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.26'
+        go-version: '1.26.5'
     - uses: actions/cache@v4
       with:
         path: |
@@ -71,7 +71,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.26'
+        go-version: '1.26.5'
     - uses: actions/cache@v4
       with:
         path: |
@@ -102,7 +102,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.26'
+        go-version: '1.26.5'
     - uses: actions/cache@v4
       with:
         path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.26'
     - uses: actions/cache@v4
       with:
         path: |
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.26'
     - uses: actions/cache@v4
       with:
         path: |
@@ -71,7 +71,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.26'
     - uses: actions/cache@v4
       with:
         path: |
@@ -102,7 +102,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.26'
     - uses: actions/cache@v4
       with:
         path: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
     unzip \
     && rm -rf /var/lib/apt/lists/* \
     && GO_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") \
-    && curl -fsSL "https://go.dev/dl/go1.25.0.linux-${GO_ARCH}.tar.gz" -o /tmp/go.tar.gz \
+    && curl -fsSL "https://go.dev/dl/go1.26.5.linux-${GO_ARCH}.tar.gz" -o /tmp/go.tar.gz \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \
     && rm /tmp/go.tar.gz
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module beatbot
 
-go 1.25.0
+go 1.26.5
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0


### PR DESCRIPTION
## Why
Go 1.26.5 is the latest stable patch, picking up security fixes in `crypto/tls`, `net`, `os`, and `syscall` — all relevant to a bot making WebSocket (Discord), HTTPS (YouTube/Spotify/Gemini), and CGO (libdave) calls. The Green Tea GC (default-on in 1.26) should also reduce GC overhead on the in-memory audio buffer workload.

## What Changed
- `go.mod`: bumps `go 1.25.0` → `go 1.26.5`
- `Dockerfile`: updates the Go tarball URL to `go1.26.5`
- `.github/workflows/ci.yml`: pins all four jobs to `go-version: '1.26.5'` (exact patch, matching the Dockerfile, so they don't silently diverge when 1.26.6 ships)