### PR TITLE
fix: DAVE MLS race condition, TTS permission spam, voice-demo guard

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	sentry "github.com/getsentry/sentry-go"
@@ -146,6 +147,7 @@ type GuildPlayer struct {
 	nowPlayingMutex       sync.Mutex
 	nowPlayingUpdateStop  chan struct{}
 	nowPlayingCurrentItem *GuildQueueItem
+	permFallbackSent      atomic.Bool // prevents per-song spam of the reinstall notice
 
 	// Player-scoped context: cancelled by Reset() to stop all ad-hoc goroutines
 	// (e.g. voice recovery retries) that don't have a dedicated stop channel.
@@ -2410,7 +2412,9 @@ func (p *GuildPlayer) sendNowPlayingCard(queueItem *GuildQueueItem) {
 	if err != nil {
 		log.Errorf("Failed to send now-playing card: %v", err)
 		if discord.IsMissingPermissions(err) {
-			discord.SendPermissionErrorFallback(textCh)
+			if p.permFallbackSent.CompareAndSwap(false, true) {
+				discord.SendPermissionErrorFallback(textCh)
+			}
 		} else {
 			sentry.CaptureException(err)
 		}

--- a/discord/dave.go
+++ b/discord/dave.go
@@ -13,11 +13,13 @@ import (
 // This is needed because godave uses defined types (UserID, ChannelID, Codec)
 // while discordgo.DaveSession uses primitive types (string, uint64, int).
 //
-// mu serializes all calls that touch the libdave C state machine. discordgo's
-// wsListen spawns a goroutine per message, so MLS ops (Init, ProcessProposals,
-// etc.) can race on the underlying DAVESessionHandle without this lock.
+// mu serializes calls that mutate libdave state (MLS session and encryptor
+// key transitions). discordgo's wsListen spawns a goroutine per message, so
+// Init/ProcessProposals/SetKeyRatchet can race on the same C handle without
+// this lock. Encrypt holds only an RLock so concurrent audio frames are not
+// serialized against each other, only against key-ratchet rotations.
 type daveSessionAdapter struct {
-	mu      sync.Mutex
+	mu      sync.RWMutex
 	session godave.Session
 }
 
@@ -32,14 +34,20 @@ func (a *daveSessionAdapter) SetChannelID(channelID uint64) {
 }
 
 func (a *daveSessionAdapter) AssignSsrcToCodec(ssrc uint32, codec int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.session.AssignSsrcToCodec(ssrc, godave.Codec(codec))
 }
 
 func (a *daveSessionAdapter) MaxEncryptedFrameSize(frameSize int) int {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
 	return a.session.MaxEncryptedFrameSize(frameSize)
 }
 
 func (a *daveSessionAdapter) Encrypt(ssrc uint32, frame []byte, encryptedFrame []byte) (int, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
 	return a.session.Encrypt(ssrc, frame, encryptedFrame)
 }
 

--- a/discord/dave.go
+++ b/discord/dave.go
@@ -2,6 +2,7 @@ package discord
 
 import (
 	"log/slog"
+	"sync"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/disgoorg/godave"
@@ -11,7 +12,12 @@ import (
 // daveSessionAdapter wraps godave.Session to implement discordgo.DaveSession.
 // This is needed because godave uses defined types (UserID, ChannelID, Codec)
 // while discordgo.DaveSession uses primitive types (string, uint64, int).
+//
+// mu serializes all calls that touch the libdave C state machine. discordgo's
+// wsListen spawns a goroutine per message, so MLS ops (Init, ProcessProposals,
+// etc.) can race on the underlying DAVESessionHandle without this lock.
 type daveSessionAdapter struct {
+	mu      sync.Mutex
 	session godave.Session
 }
 
@@ -20,6 +26,8 @@ func (a *daveSessionAdapter) MaxSupportedProtocolVersion() int {
 }
 
 func (a *daveSessionAdapter) SetChannelID(channelID uint64) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.session.SetChannelID(godave.ChannelID(channelID))
 }
 
@@ -36,42 +44,62 @@ func (a *daveSessionAdapter) Encrypt(ssrc uint32, frame []byte, encryptedFrame [
 }
 
 func (a *daveSessionAdapter) OnSelectProtocolAck(protocolVersion uint16) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.session.OnSelectProtocolAck(protocolVersion)
 }
 
 func (a *daveSessionAdapter) OnDavePrepareTransition(transitionID uint16, protocolVersion uint16) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.session.OnDavePrepareTransition(transitionID, protocolVersion)
 }
 
 func (a *daveSessionAdapter) OnDaveExecuteTransition(protocolVersion uint16) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.session.OnDaveExecuteTransition(protocolVersion)
 }
 
 func (a *daveSessionAdapter) OnDavePrepareEpoch(epoch int, protocolVersion uint16) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.session.OnDavePrepareEpoch(epoch, protocolVersion)
 }
 
 func (a *daveSessionAdapter) OnDaveMLSExternalSenderPackage(externalSenderPackage []byte) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.session.OnDaveMLSExternalSenderPackage(externalSenderPackage)
 }
 
 func (a *daveSessionAdapter) OnDaveMLSProposals(proposals []byte) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.session.OnDaveMLSProposals(proposals)
 }
 
 func (a *daveSessionAdapter) OnDaveMLSPrepareCommitTransition(transitionID uint16, commitMessage []byte) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.session.OnDaveMLSPrepareCommitTransition(transitionID, commitMessage)
 }
 
 func (a *daveSessionAdapter) OnDaveMLSWelcome(transitionID uint16, welcomeMessage []byte) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.session.OnDaveMLSWelcome(transitionID, welcomeMessage)
 }
 
 func (a *daveSessionAdapter) AddUser(userID string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.session.AddUser(godave.UserID(userID))
 }
 
 func (a *daveSessionAdapter) RemoveUser(userID string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.session.RemoveUser(godave.UserID(userID))
 }
 

--- a/handlers/playback.go
+++ b/handlers/playback.go
@@ -534,6 +534,11 @@ func (manager *Manager) handleVoiceDemo(ctx context.Context, transaction *sentry
 	encoder.SetBitrateToMax() // Explicit bitrate
 	encoder.SetComplexity(10)
 
+	if player.Player.IsPlaying() {
+		manager.SendError(interaction, "Stop the music before previewing a voice", true)
+		return
+	}
+
 	// Play TTS frames through the voice connection
 	vc.Speaking(true)
 	time.Sleep(50 * time.Millisecond)


### PR DESCRIPTION
## Why
Three bugs: DAVE MLS handshake errors from concurrent goroutine access to the libdave C session handle; the permission-error reinstall notice spamming one message per song; and `/voice-demo` garbling audio when a song is already playing.

## What Changed
- `discord/dave.go`: upgrade `sync.Mutex` to `sync.RWMutex` on `daveSessionAdapter` — `Encrypt`/`MaxEncryptedFrameSize` hold an RLock (concurrent audio frames don't block each other), while all MLS state-machine methods and `AssignSsrcToCodec` hold a write lock to serialize against key-ratchet rotations on the shared C `DAVESessionHandle`.
- `controller/controller.go`: add `permFallbackSent atomic.Bool` — the "reinstall bot" notice now sends at most once per guild session via `CompareAndSwap` instead of on every failed now-playing card.
- `handlers/playback.go`: `/voice-demo` returns early with an error if `Player.IsPlaying()` to prevent concurrent `vc.OpusSend` writes from interleaving with an active song's frames.