### PR TITLE
fix(player): stop draining audio buffer during pause (broke TTS transitions)

### DIFF
--- a/audio/player.go
+++ b/audio/player.go
@@ -254,14 +254,11 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 				continue
 			}
 
-			// Drain buffer to prevent stale data buildup
-			_, err := io.ReadFull(data.ffmpegOut, rawBuf)
-			if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
-				p.logger.Warnf("Error draining buffer during pause: %v", err)
-				sentry.CaptureException(err)
-			}
-
-			// Send silence frame to maintain stream continuity
+			// Send silence frame to maintain stream continuity.
+			// Do NOT read from the audio buffer here - the song is fully
+			// memory-buffered, so there's no pipe backpressure to relieve.
+			// Reading during pause desynchronizes position tracking from
+			// actual buffer state, causing TTS transitions to never trigger.
 			encoded, err := p.encoder.Encode(p.silenceBuffer, p.silenceOpus)
 			if err != nil {
 				p.logger.Warnf("Error encoding silence during pause: %v", err)
@@ -277,7 +274,7 @@ func (p *Player) Play(ctx context.Context, data *LoadResult, voiceChannel *disco
 				}
 			}
 
-			time.Sleep(20 * time.Millisecond) // ~50 frames per second
+			time.Sleep(20 * time.Millisecond)
 			continue
 		}
 


### PR DESCRIPTION
The pause loop was reading and discarding audio frames from the in-memory buffer every 20ms while paused. This was a vestige from the old streaming approach where pipe backpressure needed relief. With memory buffering (entire song pre-loaded into bytes.Buffer), it consumed audio silently, desynchronizing position tracking from actual buffer state.

After a long pause, the song would hit EOF before reaching the 5-second remaining window where TTS crossfade triggers, causing DJ transitions to never play. Now pause only sends silence without consuming audio frames.