### PR TITLE
fix(loader): dynamic FFmpeg timeout scaled to video duration

### DIFF
--- a/audio/loader.go
+++ b/audio/loader.go
@@ -146,13 +146,19 @@ func (l *Loader) Load(ctx context.Context, job LoadJob) {
 		done <- result{&buf, err}
 	}()
 
-	// Scale timeout with video length: at least 60s, or 1/4 of the video duration.
-	// Falls back to 3 minutes for unknown-length content (Duration == 0).
+	// Scale timeout with video length: at least 60s, or 1/4 of the video duration,
+	// capped at 30 minutes. Falls back to 3 minutes for unknown-length content.
+	// The cap matters because Load() holds l.mutex for its full duration — an
+	// unbounded timeout on a stalled multi-hour stream would block all subsequent
+	// loads for the guild.
 	loadTimeout := 3 * time.Minute
 	if job.Duration > 0 {
 		scaled := job.Duration / 4
 		if scaled < 60*time.Second {
 			scaled = 60 * time.Second
+		}
+		if scaled > 30*time.Minute {
+			scaled = 30 * time.Minute
 		}
 		loadTimeout = scaled
 	}

--- a/audio/loader.go
+++ b/audio/loader.go
@@ -22,9 +22,10 @@ type Loader struct {
 }
 
 type LoadJob struct {
-	URL     string
-	VideoID string
-	Title   string
+	URL      string
+	VideoID  string
+	Title    string
+	Duration time.Duration
 }
 
 type LoadResult struct {
@@ -145,6 +146,17 @@ func (l *Loader) Load(ctx context.Context, job LoadJob) {
 		done <- result{&buf, err}
 	}()
 
+	// Scale timeout with video length: at least 60s, or 1/4 of the video duration.
+	// Falls back to 3 minutes for unknown-length content (Duration == 0).
+	loadTimeout := 3 * time.Minute
+	if job.Duration > 0 {
+		scaled := job.Duration / 4
+		if scaled < 60*time.Second {
+			scaled = 60 * time.Second
+		}
+		loadTimeout = scaled
+	}
+
 	// Wait for FFmpeg to complete, handle cancellation or timeout
 	select {
 	case <-l.canceled:
@@ -229,8 +241,8 @@ func (l *Loader) Load(ctx context.Context, job LoadJob) {
 		log.Tracef("sent loaded event for %s", job.VideoID)
 		return
 
-	case <-time.After(30 * time.Second):
-		errMsg := "ffmpeg timed out after 30 seconds"
+	case <-time.After(loadTimeout):
+		errMsg := "ffmpeg timed out after " + loadTimeout.Round(time.Second).String()
 		if stderr.Len() > 0 {
 			errMsg += " | ffmpeg stderr: " + stderr.String()
 		}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -503,9 +503,10 @@ func (p *GuildPlayer) loadNext() {
 			ctx = context.Background()
 		}
 		go p.Loader.Load(ctx, audio.LoadJob{
-			URL:     next.Stream.StreamURL,
-			VideoID: next.Video.VideoID,
-			Title:   next.Video.Title,
+			URL:      next.Stream.StreamURL,
+			VideoID:  next.Video.VideoID,
+			Title:    next.Video.Title,
+			Duration: next.Video.Duration,
 		})
 	}
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -544,9 +544,10 @@ func (p *GuildPlayer) playNext() {
 			// load the stream
 			// playback will start when the loader has finished
 			go p.Loader.Load(ctx, audio.LoadJob{
-				URL:     next.Stream.StreamURL,
-				VideoID: next.Video.VideoID,
-				Title:   next.Video.Title,
+				URL:      next.Stream.StreamURL,
+				VideoID:  next.Video.VideoID,
+				Title:    next.Video.Title,
+				Duration: next.Video.Duration,
 			})
 		} else {
 			// if song has already been loaded, play it
@@ -685,9 +686,10 @@ streamReady:
 			nextCtx = context.Background()
 		}
 		go p.Loader.Load(nextCtx, audio.LoadJob{
-			URL:     next.Stream.StreamURL,
-			VideoID: next.Video.VideoID,
-			Title:   next.Video.Title,
+			URL:      next.Stream.StreamURL,
+			VideoID:  next.Video.VideoID,
+			Title:    next.Video.Title,
+			Duration: next.Video.Duration,
 		})
 		return
 	}


### PR DESCRIPTION
## Why

The hardcoded 30-second FFmpeg timeout caused long-form content (live sets, mixes, DJ recordings) to always fail loading — a 30-minute video needs far more than 30 seconds to buffer.

## What Changed

- Added `Duration time.Duration` to `LoadJob` so the loader knows the video length upfront
- Timeout now scales to `max(60s, Duration/4)`, capped at 30 minutes to bound the mutex hold time (Load holds `l.mutex` for its full duration, blocking subsequent guild loads if stalled)
- Falls back to 3 minutes when duration is unknown (YouTube API didn't return it)
- Fixed all three `LoadJob` construction sites in controller — the initial pass only updated `loadNext()`; `playNext()` and the stream-ready handler were also missing `Duration`
- Timeout message now reports the actual value used (e.g. `ffmpeg timed out after 7m30s`)