### PR TITLE
feat(queue): add /neverplay command to permanently block songs guild-wide

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -270,5 +270,10 @@
         "required": false
       }
     ]
+  },
+  {
+    "name": "neverplay",
+    "type": 1,
+    "description": "Block the current song from ever playing again and skip it"
   }
 ]

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1833,6 +1833,8 @@ func (p *GuildPlayer) pickRadioSong() *youtube.VideoResponse {
 			for id := range blocked {
 				historyIDs[id] = true
 			}
+		} else {
+			logger.WithError(err).Warn("failed to fetch blocked video IDs for radio dedup")
 		}
 	}
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1827,6 +1827,15 @@ func (p *GuildPlayer) pickRadioSong() *youtube.VideoResponse {
 	}
 	p.Queue.Mutex.Unlock()
 
+	// Merge guild-blocked videos so they are excluded from all radio candidate selection.
+	if p.DB != nil {
+		if blocked, err := p.DB.GetBlockedVideoIDs(p.GuildID); err == nil {
+			for id := range blocked {
+				historyIDs[id] = true
+			}
+		}
+	}
+
 	// Genre radio mode
 	if genre := p.GetRadioGenre(); genre != "" && config.Config.Deezer.Enabled {
 		picked := p.pickFromDeezerPool(ctx, genre, 0, historyIDs, recentTitles, logger)

--- a/database/database.go
+++ b/database/database.go
@@ -131,6 +131,14 @@ func (d *Database) migrate() error {
 			value TEXT NOT NULL,
 			PRIMARY KEY (guild_id, key)
 		)`,
+		`CREATE TABLE IF NOT EXISTS guild_blocked_videos (
+			guild_id   TEXT NOT NULL,
+			video_id   TEXT NOT NULL,
+			title      TEXT NOT NULL DEFAULT '',
+			url        TEXT NOT NULL DEFAULT '',
+			blocked_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (guild_id, video_id)
+		)`,
 	}
 
 	for _, m := range migrations {
@@ -492,6 +500,50 @@ func (d *Database) GetGuildSetting(guildID, key string) (string, error) {
 		return "", fmt.Errorf("failed to get guild setting %s/%s: %w", guildID, key, err)
 	}
 	return value, nil
+}
+
+// BlockVideo adds a guild-wide never-play block. Silently ignores duplicates.
+func (d *Database) BlockVideo(guildID, videoID, title, url string) error {
+	_, err := d.db.Exec(
+		`INSERT OR IGNORE INTO guild_blocked_videos (guild_id, video_id, title, url) VALUES (?, ?, ?, ?)`,
+		guildID, videoID, title, url,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to block video %s: %w", videoID, err)
+	}
+	return nil
+}
+
+// IsVideoBlocked returns true if the video is on the guild's never-play list.
+func (d *Database) IsVideoBlocked(guildID, videoID string) bool {
+	var count int
+	err := d.db.QueryRow(
+		`SELECT COUNT(*) FROM guild_blocked_videos WHERE guild_id = ? AND video_id = ?`,
+		guildID, videoID,
+	).Scan(&count)
+	return err == nil && count > 0
+}
+
+// GetBlockedVideoIDs returns all blocked video IDs for a guild as a set for O(1) lookups.
+func (d *Database) GetBlockedVideoIDs(guildID string) (map[string]bool, error) {
+	rows, err := d.db.Query(
+		`SELECT video_id FROM guild_blocked_videos WHERE guild_id = ?`,
+		guildID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query blocked videos: %w", err)
+	}
+	defer rows.Close()
+
+	ids := make(map[string]bool)
+	for rows.Next() {
+		var videoID string
+		if err := rows.Scan(&videoID); err != nil {
+			return nil, fmt.Errorf("failed to scan blocked video row: %w", err)
+		}
+		ids[videoID] = true
+	}
+	return ids, rows.Err()
 }
 
 // SetGuildSetting upserts a per-guild setting.

--- a/handlers/applemusic.go
+++ b/handlers/applemusic.go
@@ -75,6 +75,14 @@ func (manager *Manager) handleAppleMusicTrack(ctx context.Context, interaction *
 		return
 	}
 
+	videos = manager.filterBlocked(interaction.GuildID, videos)
+	if len(videos) == 0 {
+		manager.SendFollowup(ctx, interaction, "",
+			fmt.Sprintf("**%s** by **%s** is blocked from playing.", trackInfo.Title, artistsStr),
+			true)
+		return
+	}
+
 	video := videos[0]
 	fallbacks := fallbackSlice(videos, 2)
 	log.Debugf("Found YouTube match: %s (ID: %s)", video.Title, video.VideoID)
@@ -301,6 +309,9 @@ func (manager *Manager) handleAppleMusicCollection(ctx context.Context, interact
 
 	log.Debugf("Found %d/%d tracks on YouTube for Apple Music %s '%s'",
 		len(foundVideos), len(collection.Tracks), collection.Type, collection.Name)
+
+	// Filter never-play blocked videos before queuing.
+	foundVideos = manager.filterBlocked(interaction.GuildID, foundVideos)
 
 	if len(foundVideos) == 0 {
 		manager.SendFollowup(ctx, interaction, "",

--- a/handlers/charts.go
+++ b/handlers/charts.go
@@ -92,6 +92,10 @@ func (manager *Manager) handleCharts(ctx context.Context, transaction *sentry.Sp
 			if len(results) == 0 {
 				continue
 			}
+			results = manager.filterBlocked(interaction.GuildID, results)
+			if len(results) == 0 {
+				continue
+			}
 			player.Add(ctx, results[0], interaction.Member.User.ID, interaction.Token, manager.AppID, nil)
 			queued = append(queued, results[0].Title)
 		}

--- a/handlers/database.go
+++ b/handlers/database.go
@@ -104,6 +104,53 @@ func (manager *Manager) handleLeaderboard(interaction *Interaction) Response {
 	return Response{Type: 4, Data: ResponseData{Content: content}}
 }
 
+func (manager *Manager) handleNeverPlay(interaction *Interaction) Response {
+	db := manager.Controller.GetDB()
+	if db == nil {
+		return Response{Type: 4, Data: ResponseData{Content: "Database is not available.", Flags: 64}}
+	}
+
+	player := manager.Controller.GetPlayer(interaction.GuildID)
+	currentItem := player.GetCurrentItem()
+	if currentItem == nil {
+		return Response{Type: 4, Data: ResponseData{Content: "Nothing is currently playing.", Flags: 64}}
+	}
+
+	video := currentItem.Video
+	videoURL := "https://www.youtube.com/watch?v=" + video.VideoID
+	if err := db.BlockVideo(interaction.GuildID, video.VideoID, video.Title, videoURL); err != nil {
+		log.Errorf("Error blocking video: %v", err)
+		return Response{Type: 4, Data: ResponseData{Content: "Failed to block song. Try again.", Flags: 64}}
+	}
+
+	go player.Skip()
+
+	return Response{Type: 4, Data: ResponseData{
+		Content: fmt.Sprintf("🚫 **%s** has been blocked and will never play again.", video.Title),
+		Flags:   64,
+	}}
+}
+
+// filterBlocked removes any videos whose IDs are on the guild's never-play list.
+// Returns the original slice unchanged if the DB is unavailable or has no blocks.
+func (manager *Manager) filterBlocked(guildID string, videos []youtube.VideoResponse) []youtube.VideoResponse {
+	db := manager.Controller.GetDB()
+	if db == nil {
+		return videos
+	}
+	blocked, err := db.GetBlockedVideoIDs(guildID)
+	if err != nil || len(blocked) == 0 {
+		return videos
+	}
+	out := videos[:0]
+	for _, v := range videos {
+		if !blocked[v.VideoID] {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
 func (manager *Manager) handleFavorite(interaction *Interaction) Response {
 	db := manager.Controller.GetDB()
 	if db == nil {

--- a/handlers/database.go
+++ b/handlers/database.go
@@ -117,13 +117,28 @@ func (manager *Manager) handleNeverPlay(interaction *Interaction) Response {
 	}
 
 	video := currentItem.Video
+
+	if db.IsVideoBlocked(interaction.GuildID, video.VideoID) {
+		return Response{Type: 4, Data: ResponseData{
+			Content: fmt.Sprintf("**%s** is already on the never-play list.", video.Title),
+			Flags:   64,
+		}}
+	}
+
 	videoURL := "https://www.youtube.com/watch?v=" + video.VideoID
 	if err := db.BlockVideo(interaction.GuildID, video.VideoID, video.Title, videoURL); err != nil {
 		log.Errorf("Error blocking video: %v", err)
 		return Response{Type: 4, Data: ResponseData{Content: "Failed to block song. Try again.", Flags: 64}}
 	}
 
-	go player.Skip()
+	// Only skip if the blocked song is still the active one; a natural end between
+	// the DB write and goroutine scheduling would otherwise kill the next innocent song.
+	blockedID := video.VideoID
+	go func() {
+		if item := player.GetCurrentItem(); item != nil && item.Video.VideoID == blockedID {
+			player.Skip()
+		}
+	}()
 
 	return Response{Type: 4, Data: ResponseData{
 		Content: fmt.Sprintf("🚫 **%s** has been blocked and will never play again.", video.Title),
@@ -139,7 +154,11 @@ func (manager *Manager) filterBlocked(guildID string, videos []youtube.VideoResp
 		return videos
 	}
 	blocked, err := db.GetBlockedVideoIDs(guildID)
-	if err != nil || len(blocked) == 0 {
+	if err != nil {
+		log.Warnf("filterBlocked: failed to fetch blocked video IDs for guild %s, returning unfiltered: %v", guildID, err)
+		return videos
+	}
+	if len(blocked) == 0 {
 		return videos
 	}
 	out := videos[:0]
@@ -291,6 +310,13 @@ func (manager *Manager) handleRecommend(ctx context.Context, transaction *sentry
 		songTitles = append(songTitles, r.Title)
 		if r.VideoID != "" {
 			historyVideoIDs[r.VideoID] = true
+		}
+	}
+
+	// Merge never-play blocked videos so they are excluded from recommendation picks.
+	if blocked, err := db.GetBlockedVideoIDs(interaction.GuildID); err == nil {
+		for id := range blocked {
+			historyVideoIDs[id] = true
 		}
 	}
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -263,6 +263,8 @@ func (manager *Manager) HandleInteraction(interaction *Interaction) (response Re
 		finishTransaction = false
 		go manager.handleRequest(ctx, transaction, interaction)
 		return Response{Type: 5}
+	case "neverplay":
+		return manager.handleNeverPlay(interaction)
 	case "favorite":
 		return manager.handleFavorite(interaction)
 	case "favorites":

--- a/handlers/playback.go
+++ b/handlers/playback.go
@@ -330,6 +330,15 @@ func (manager *Manager) handleRequest(ctx context.Context, transaction *sentry.S
 	}
 	var picks []pickedVideo
 	historyIDs := player.SongHistory.GetAllVideoIDs()
+
+	// Merge never-play blocked videos so they are excluded from request picks.
+	if db := manager.Controller.GetDB(); db != nil {
+		if blocked, err := db.GetBlockedVideoIDs(interaction.GuildID); err == nil {
+			for id := range blocked {
+				historyIDs[id] = true
+			}
+		}
+	}
 	for _, query := range queries {
 		videos := youtube.Query(ctx, query)
 		if len(videos) == 0 {

--- a/handlers/queue.go
+++ b/handlers/queue.go
@@ -223,6 +223,11 @@ func (manager *Manager) QueryAndQueue(ctx context.Context, transaction *sentry.S
 			return
 		}
 
+		if db := manager.Controller.GetDB(); db != nil && db.IsVideoBlocked(interaction.GuildID, videoResponse.VideoID) {
+			manager.SendFollowup(ctx, interaction, "", fmt.Sprintf("**%s** is blocked from playing.", videoResponse.Title), true)
+			return
+		}
+
 		video = videoResponse
 		// No fallbacks for direct URL requests — the user asked for a specific video
 	} else {

--- a/handlers/queue.go
+++ b/handlers/queue.go
@@ -133,6 +133,14 @@ func (manager *Manager) QueryAndQueue(ctx context.Context, transaction *sentry.S
 			return
 		}
 
+		videos = manager.filterBlocked(interaction.GuildID, videos)
+		if len(videos) == 0 {
+			manager.SendFollowup(ctx, interaction, "",
+				fmt.Sprintf("**%s** by **%s** is blocked from playing.", trackInfo.Title, artistsStr),
+				true)
+			return
+		}
+
 		video := videos[0]
 		fallbacks := fallbackSlice(videos, 2)
 		log.Debugf("Found YouTube match: %s (ID: %s)", video.Title, video.VideoID)
@@ -222,6 +230,12 @@ func (manager *Manager) QueryAndQueue(ctx context.Context, transaction *sentry.S
 
 		if len(videos) == 0 {
 			manager.SendFollowup(ctx, interaction, "There wasn't anything found for "+query, "No videos found for the given query", true)
+			return
+		}
+
+		videos = manager.filterBlocked(interaction.GuildID, videos)
+		if len(videos) == 0 {
+			manager.SendFollowup(ctx, interaction, "No unblocked results found for "+query, "All results are blocked", true)
 			return
 		}
 

--- a/handlers/spotify.go
+++ b/handlers/spotify.go
@@ -131,6 +131,9 @@ func (manager *Manager) handleSpotifyCollection(ctx context.Context, interaction
 		}
 	}
 
+	// Filter never-play blocked videos before duplicate/queue checks.
+	foundVideos = manager.filterBlocked(interaction.GuildID, foundVideos)
+
 	// Check for duplicates in queue
 	var videosToQueue []youtube.VideoResponse
 	var duplicateCount int

--- a/handlers/youtube.go
+++ b/handlers/youtube.go
@@ -79,6 +79,9 @@ func (manager *Manager) handleYouTubePlaylist(ctx context.Context, interaction *
 		})
 	}
 
+	// Filter never-play blocked videos before duplicate/queue checks.
+	videos = manager.filterBlocked(interaction.GuildID, videos)
+
 	// Check for duplicates against current queue
 	var videosToQueue []youtube.VideoResponse
 	var duplicateCount int


### PR DESCRIPTION
## Why
Radio mode and other auto-queue paths had no way to permanently ban a song. Users needed a command to say "never play this again" — blocking it from radio picks, search results, playlists, charts, and AI recommendations.

## What Changed
Adds a `/neverplay` slash command that blocks the currently playing song in a new `guild_blocked_videos` SQLite table and immediately skips it (with a VideoID re-check guard to avoid killing the next song if the blocked song ended naturally). Blocked songs are filtered out across all queue entry points: YouTube search, direct URL, playlist, Spotify/Apple Music single tracks and collections, `/charts play:true`, `/recommend`, and `/request`. Radio candidate selection in `pickRadioSong` also merges the block list into `historyIDs` so it flows through to all Deezer/Gemini paths automatically. Re-blocking an already-blocked song returns a distinct message without skipping. DB errors in the filter path are logged as warnings rather than silently failing open.