### PR TITLE
fix(tts): resolve stale guild voices after provider switch

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1639,7 +1639,7 @@ func (p *GuildPlayer) startRadioMode() {
 		if script != "" {
 			ttsCtx, ttsCancel := context.WithTimeout(ctx, gemini.TTSTimeout)
 			defer ttsCancel()
-			audioBytes, err := tts.Get().Synthesize(ttsCtx, script, p.GetAnnounceVoice())
+			audioBytes, err := tts.Get().Synthesize(ttsCtx, script, tts.ResolveVoice(p.GetAnnounceVoice()))
 			if err != nil {
 				log.Errorf("Radio start TTS generation failed: %v", err)
 				sentry.CaptureException(err)
@@ -2747,7 +2747,7 @@ func (p *GuildPlayer) generateTransitionTTS() {
 
 	ttsCtx, ttsCancel := context.WithTimeout(ctx, gemini.TTSTimeout)
 	defer ttsCancel()
-	audioBytes, err := tts.Get().Synthesize(ttsCtx, script, p.GetAnnounceVoice())
+	audioBytes, err := tts.Get().Synthesize(ttsCtx, script, tts.ResolveVoice(p.GetAnnounceVoice()))
 	if err != nil {
 		log.Errorf("TTS generation failed: %v", err)
 		sentry.CaptureException(err)
@@ -2786,7 +2786,7 @@ func (p *GuildPlayer) playNoMoreSongsMessage() {
 
 	ttsCtx, ttsCancel := context.WithTimeout(ctx, gemini.TTSTimeout)
 	defer ttsCancel()
-	audioBytes, err := tts.Get().Synthesize(ttsCtx, script, p.GetAnnounceVoice())
+	audioBytes, err := tts.Get().Synthesize(ttsCtx, script, tts.ResolveVoice(p.GetAnnounceVoice()))
 	if err != nil {
 		log.Errorf("No-more-songs TTS generation failed: %v", err)
 		sentry.CaptureException(err)

--- a/handlers/playback.go
+++ b/handlers/playback.go
@@ -537,7 +537,7 @@ func (manager *Manager) handleVoiceDemo(ctx context.Context, transaction *sentry
 		manager.SendError(interaction, "TTS provider not configured", true)
 		return
 	}
-	audioBytes, err := provider.Synthesize(ctx, script, voice)
+	audioBytes, err := provider.Synthesize(ctx, script, tts.ResolveVoice(voice))
 	if err != nil {
 		log.Errorf("TTS generation failed: %v", err)
 		sentryhelper.CaptureException(ctx, err)

--- a/tts/provider.go
+++ b/tts/provider.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"beatbot/config"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // Provider abstracts TTS audio synthesis so the bot can swap between
@@ -30,7 +32,12 @@ type Provider interface {
 	AcceptsCustomVoices() bool
 }
 
-var defaultProvider Provider
+var (
+	defaultProvider Provider
+	// staleVoices holds built-in voices from inactive providers, used by
+	// ResolveVoice to detect voices left over after a provider switch.
+	staleVoices []string
+)
 
 // Init initializes the TTS provider based on config.Config.TTSProvider.
 // Must be called after config.NewConfig() and gemini.Init().
@@ -42,8 +49,10 @@ func Init() error {
 			return fmt.Errorf("grok TTS init: %w", err)
 		}
 		defaultProvider = p
+		staleVoices = (&geminiProvider{}).Voices()
 	case "gemini", "":
 		defaultProvider = newGeminiProvider()
+		staleVoices = grokBuiltinVoices
 	default:
 		return fmt.Errorf("unknown TTS_PROVIDER: %q (valid: gemini, grok)", config.Config.TTSProvider)
 	}
@@ -71,4 +80,45 @@ func ValidateVoice(name string) (string, bool) {
 		return name, true
 	}
 	return "", false
+}
+
+// ResolveVoice validates a stored guild voice against the active provider,
+// falling back to the provider's default when the voice is stale (e.g. a
+// Gemini voice left in the DB after switching to Grok).
+func ResolveVoice(stored string) string {
+	p := Get()
+	if p == nil {
+		return stored
+	}
+	if stored == "" {
+		return p.DefaultVoice()
+	}
+	// Current provider's built-in list — use canonical casing
+	for _, v := range p.Voices() {
+		if strings.EqualFold(v, stored) {
+			return v
+		}
+	}
+	// For custom-voice providers: distinguish legitimate custom voices
+	// from stale voices left after a provider switch
+	if p.AcceptsCustomVoices() {
+		for _, v := range staleVoices {
+			if strings.EqualFold(v, stored) {
+				log.WithFields(log.Fields{
+					"module":   "tts",
+					"stored":   stored,
+					"fallback": p.DefaultVoice(),
+				}).Warn("Stored voice belongs to another provider, using default")
+				return p.DefaultVoice()
+			}
+		}
+		return stored
+	}
+	// Not valid for current provider
+	log.WithFields(log.Fields{
+		"module":   "tts",
+		"stored":   stored,
+		"fallback": p.DefaultVoice(),
+	}).Warn("Stored voice not valid for current provider, using default")
+	return p.DefaultVoice()
 }


### PR DESCRIPTION
## Summary

- Adds `tts.ResolveVoice()` that validates a guild's stored voice against the active TTS provider before synthesis
- Detects stale voices from the inactive provider (e.g. Gemini's "Algenib" stored in DB when Grok is active) and falls back to the current provider's default with a warning log
- Custom/cloned voice IDs that aren't in any built-in list still pass through for xAI
- All 4 TTS call sites (transition, radio start, queue empty, voice-demo) now resolve voices before synthesis

## Test plan

- [ ] Set a Gemini voice via `/announce voice:Algenib`, switch to `TTS_PROVIDER=grok`, verify TTS uses default "carina" instead of 404ing
- [ ] Set a valid Grok voice, verify it's used as-is
- [ ] Set a custom xAI voice ID, verify it passes through without fallback
- [ ] Switch back to `TTS_PROVIDER=gemini` with a Grok voice stored, verify fallback to "Aoede"