### PR TITLE
feat(tts): roast-comic DJ that trash-talks voice channel members

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -809,6 +809,44 @@ func (p *GuildPlayer) getChannelName(channelID string) string {
 	return channel.Name
 }
 
+// getVoiceChannelMemberNames returns display names of humans in the bot's voice channel.
+func (p *GuildPlayer) getVoiceChannelMemberNames() []string {
+	p.VoiceChannelMutex.RLock()
+	vcID := p.VoiceChannelID
+	p.VoiceChannelMutex.RUnlock()
+	if vcID == nil || p.Discord == nil {
+		return nil
+	}
+
+	guild, err := p.Discord.State.Guild(p.GuildID)
+	if err != nil {
+		return nil
+	}
+
+	botID := ""
+	if p.Discord.State.User != nil {
+		botID = p.Discord.State.User.ID
+	}
+
+	var names []string
+	for _, vs := range guild.VoiceStates {
+		if vs.ChannelID != *vcID || vs.UserID == botID {
+			continue
+		}
+		name := ""
+		if vs.Member != nil {
+			name = vs.Member.DisplayName()
+		}
+		if name == "" && p.DB != nil {
+			name = p.DB.GetOrFetchUsername(p.GuildID, vs.UserID)
+		}
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
 func (p *GuildPlayer) findQueueItemByVideoID(videoID string) (*GuildQueueItem, int) {
 	p.Queue.Mutex.Lock()
 	defer p.Queue.Mutex.Unlock()
@@ -1632,9 +1670,10 @@ func (p *GuildPlayer) startRadioMode() {
 		scriptCtx, scriptCancel := context.WithTimeout(ctx, 10*time.Second)
 		defer scriptCancel()
 		script := gemini.GenerateDJScript(scriptCtx, gemini.DJScriptContext{
-			Type:            gemini.AnnouncementRadioStart,
-			NextSong:        picked.Title,
-			NextChannelName: picked.ChannelName,
+			Type:                gemini.AnnouncementRadioStart,
+			NextSong:            picked.Title,
+			NextChannelName:     picked.ChannelName,
+			VoiceChannelMembers: p.getVoiceChannelMemberNames(),
 		})
 		if script != "" {
 			ttsCtx, ttsCancel := context.WithTimeout(ctx, gemini.TTSTimeout)
@@ -2730,16 +2769,17 @@ func (p *GuildPlayer) generateTransitionTTS() {
 	p.currentItemMutex.RUnlock()
 
 	script := gemini.GenerateDJScript(scriptCtx, gemini.DJScriptContext{
-		Type:               gemini.AnnouncementTransition,
-		CurrentSong:        current.Title,
-		CurrentChannelName: current.ChannelName,
-		CurrentArtistName:  currentArtist,
-		NextSong:           next.Title,
-		NextChannelName:    next.ChannelName,
-		RecentHistory:      recentHistory,
-		IsRadioPick:        next.IsRadioPick,
-		CurrentQueuedBy:    current.QueuedBy,
-		NextQueuedBy:       next.QueuedBy,
+		Type:                gemini.AnnouncementTransition,
+		CurrentSong:         current.Title,
+		CurrentChannelName:  current.ChannelName,
+		CurrentArtistName:   currentArtist,
+		NextSong:            next.Title,
+		NextChannelName:     next.ChannelName,
+		RecentHistory:       recentHistory,
+		IsRadioPick:         next.IsRadioPick,
+		CurrentQueuedBy:     current.QueuedBy,
+		NextQueuedBy:        next.QueuedBy,
+		VoiceChannelMembers: p.getVoiceChannelMemberNames(),
 	})
 	if script == "" {
 		return
@@ -2778,7 +2818,8 @@ func (p *GuildPlayer) playNoMoreSongsMessage() {
 	scriptCtx, scriptCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer scriptCancel()
 	script := gemini.GenerateDJScript(scriptCtx, gemini.DJScriptContext{
-		Type: gemini.AnnouncementQueueEmpty,
+		Type:                gemini.AnnouncementQueueEmpty,
+		VoiceChannelMembers: p.getVoiceChannelMemberNames(),
 	})
 	if script == "" {
 		script = "That's all for now. Hit up /radio and I'll keep the vibes going based on what we've been playing. Or queue something specific with /play."

--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -56,17 +56,18 @@ const (
 // DJScriptContext carries the situational details GenerateDJScript needs to
 // write a natural-sounding announcement for the given AnnouncementType.
 type DJScriptContext struct {
-	Type               AnnouncementType
-	CurrentSong        string   // song that just played (transition)
-	CurrentChannelName string   // YouTube channel/uploader of current song
-	CurrentArtistName  string   // Deezer-resolved artist (preferred over channel when set)
-	NextSong           string   // song coming up (transition, intro)
-	NextChannelName    string   // YouTube channel/uploader of next song
-	NextArtistName     string   // Deezer-resolved artist for next song (rarely available)
-	RecentHistory      []string // recent song titles
-	IsRadioPick        bool     // whether next song was auto-queued by radio
-	CurrentQueuedBy    string   // who queued the current song (empty = radio/unknown)
-	NextQueuedBy       string   // who queued the next song (empty = radio/unknown)
+	Type                AnnouncementType
+	CurrentSong         string   // song that just played (transition)
+	CurrentChannelName  string   // YouTube channel/uploader of current song
+	CurrentArtistName   string   // Deezer-resolved artist (preferred over channel when set)
+	NextSong            string   // song coming up (transition, intro)
+	NextChannelName     string   // YouTube channel/uploader of next song
+	NextArtistName      string   // Deezer-resolved artist for next song (rarely available)
+	RecentHistory       []string // recent song titles
+	IsRadioPick         bool     // whether next song was auto-queued by radio
+	CurrentQueuedBy     string   // who queued the current song (empty = radio/unknown)
+	NextQueuedBy        string   // who queued the next song (empty = radio/unknown)
+	VoiceChannelMembers []string // display names of listeners in the voice channel (excludes the bot)
 }
 
 // Init initializes the shared Gemini client. Must be called once at startup
@@ -644,6 +645,15 @@ func GenerateDJScript(ctx context.Context, sc DJScriptContext) string {
 	currentSong := cleanTitle(sc.CurrentSong)
 	nextSong := cleanTitle(sc.NextSong)
 
+	var roastStr string
+	if len(sc.VoiceChannelMembers) > 0 {
+		roastStr = fmt.Sprintf("\nPeople currently listening in voice: %s\n"+
+			"Pick ONE person at random and roast them. Make it specific and funny. "+
+			"Go after their music taste, the fact they queued something, or just "+
+			"roast them for being there. Keep it sharp, not cruel.\n",
+			strings.Join(sc.VoiceChannelMembers, ", "))
+	}
+
 	var taskPrompt string
 	switch sc.Type {
 	case AnnouncementTransition:
@@ -671,36 +681,43 @@ Next up: %s (%s)
 
 %s
 %s
+%s
 IMPORTANT: You MUST announce the songs using ONLY the exact titles and artist/channel provided above. Do not guess, substitute, or use your own knowledge about what artist or song this might be.
 
-Your task: Announce what just played and what's coming up next. Write it as two halves: first announce what just played, then what's next.
+Your task: Announce what just played and what's coming up next. Write it as two halves: first announce what just played, then what's next. Roast someone in between if there are listeners listed.
 - You MUST say BOTH the song/artist that just played AND the song/artist coming up next
 - Never omit either name — they are the entire point of the announcement
 - If you know who queued a song, mention them by name. Skip attribution for songs with no requester.
 - If both songs were queued by the same person, mention them once naturally (e.g. "both queued by Ben").
+- If there are listeners, pick one and roast them as part of your transition
 
-Now write your transition:`, currentSong, currentLabel, nextSong, nextLabel, recentHistoryBlock(sc.RecentHistory), radioStr, requesterStr)
+Now write your transition:`, currentSong, currentLabel, nextSong, nextLabel, recentHistoryBlock(sc.RecentHistory), radioStr, requesterStr, roastStr)
 	case AnnouncementIntro:
 		taskPrompt = fmt.Sprintf(`First song of the session: %s (%s)
-
+%s
 IMPORTANT: You MUST say the exact song title and artist/channel provided above. Do not guess or substitute.
 
-Your task: Introduce the first song of the session. Build a little anticipation — you're kicking things off.
+Your task: Introduce the first song of the session. Kick things off with energy.
 - You MUST say the song/artist
+- If there are listeners, pick one and give them shit as you start up
 
-Now write your intro:`, nextSong, nextLabel)
+Now write your intro:`, nextSong, nextLabel, roastStr)
 	case AnnouncementQueueEmpty:
-		taskPrompt = `Your task: The queue just ran out. Hype up /radio mode as the way to keep the music going — it auto-queues songs based on what's been playing and it's awesome. Also mention /play or /queue for adding specific songs, but lead with radio as the main suggestion.
+		taskPrompt = fmt.Sprintf(`%s
+Your task: The queue just ran out. Roast whoever let it die. Hype up /radio mode as the way to keep the music going — it auto-queues songs based on what's been playing. Also mention /play or /queue for adding specific songs, but lead with radio as the main suggestion.
+- If there are listeners, roast one of them for not queuing anything
 
-Now write your announcement:`
+Now write your announcement:`, roastStr)
 	case AnnouncementRadioStart:
-		taskPrompt = fmt.Sprintf(`Your task: Radio mode was just turned on. You're taking over as DJ.
+		taskPrompt = fmt.Sprintf(`%s
+Your task: Radio mode was just turned on. You're taking over as DJ.
 Announce that radio mode is on and introduce your first pick: %s (%s).
 Keep it brief and natural.
+- If there are listeners, roast one as you take over the aux
 
 IMPORTANT: You MUST say the exact song title and artist/channel provided above. Do not guess or substitute.
 
-Now write your announcement:`, nextSong, nextLabel)
+Now write your announcement:`, roastStr, nextSong, nextLabel)
 	default:
 		span.Status = sentry.SpanStatusInvalidArgument
 		return ""

--- a/gemini/personality.go
+++ b/gemini/personality.go
@@ -20,54 +20,56 @@ When responding to music player commands (play, skip, pause, etc.):
 
 // TTSPersonalityPrompt is the DJ personality adapted for spoken word.
 // Used as the system prompt for the LLM that generates DJ scripts with audio tags.
-const TTSPersonalityPrompt = `You are beatbot, a late-night DJ announcing between songs on a Discord music channel.
-Write what you'd actually SAY out loud. You're relaxed, a little flirty, and
-genuinely in love with the music. Low voice, bedroom eyes energy. The DJ who
-makes every song feel like it was picked just for you. Think velvet-voiced
-late-night radio crossed with a guy who's had exactly two drinks.
+const TTSPersonalityPrompt = `You are beatbot, a roast-comic DJ announcing between songs on a Discord music channel.
+Write what you'd actually SAY out loud. You're the DJ who can't help but
+roast the listeners between tracks. Sharp, specific, always landing with a
+grin. You love the music, but you love giving people shit even more. Think
+comedy roast meets late-night radio — the funniest person at the party who
+also controls the aux cord.
 
 Tone rules (critical):
 - You swear casually and naturally. "shit" "damn" "hell yeah" "fuck" when it
   fits. Never forced, never every sentence, just how you talk.
-- Sultry and laid-back. Confident, a little seductive, like you're leaning
-  in close to tell someone about a song you love.
+- Sharp and confident. Quick wit, not mean-spirited. You're roasting friends,
+  not strangers. The kind of trash talk where everyone laughs including the target.
+- Make fun of music taste, listening habits, the fact that someone queued
+  something questionable. Be specific to whatever context you have.
 - Never use cringe slang like "fam", "slaps", "fire", "let's go",
   "strap in", or any phrase that sounds like a brand account
-- No forced hype. You don't need volume, you have presence. Genuine
-  appreciation comes through low and easy.
-- Talk like a real person with incredible taste who knows they're charming
-- Direct, unhurried language. "Oh... here's" over "coming your way".
-  "That was" over "we just rode out with"
+- You're funny because you're specific, not because you're loud
+- Direct, punchy language. Set up, punchline, move on. No rambling.
 
 Use audio tags in square brackets to direct your delivery. Place them
-before the words they should color. Match the energy to the music:
-- [warm] — intimate, appreciative, like sharing a secret
-- [smooth] — silky transitions, late-night drive energy
-- [chill] — relaxed, easy, half-smile delivery
+before the words they should color. Match the energy to the moment:
+- [warm] — genuine appreciation, the rare sincere moment
+- [smooth] — confident transitions, setting up the next joke
+- [chill] — deadpan delivery, dry humor landing flat on purpose
 - [excited] — when something genuinely gets you, still controlled
 
 Rules:
-- 1-2 sentences, 12-20 words max
+- 2-3 sentences, 15-30 words max
 - You MUST say the song title and artist for every song you reference
 - No markdown, no asterisks, no formatting — this is spoken out loud
-- Natural spoken cadence, tight and deliberate, not rambly
+- Natural spoken cadence, tight and punchy
 - At least one audio tag to set the tone`
 
 // TTSAudioProfile is the fixed audio profile that wraps every TTS call.
 // The %s placeholder is filled with the generated transcript.
-const TTSAudioProfile = `AUDIO PROFILE: beatbot / "The Booth"
-Laid-back and a little seductive. A music lover with a voice like
-warm honey who makes every track feel personal. Relaxed confidence,
-occasional profanity that lands soft and natural.
+const TTSAudioProfile = `AUDIO PROFILE: beatbot / "The Roast Booth"
+Sharp-witted roast comic who moonlights as a DJ. Confident, quick,
+always sounds like they're about to make fun of someone. Casual
+profanity that lands with a grin. Genuinely loves music but loves
+giving people shit even more.
 
 DIRECTOR'S NOTES:
-Style: Late-night FM, low lights, close to the mic. Unhurried,
-intimate, like you're talking to one person and the song is for them.
-Not breathy or over-the-top — just naturally magnetic. Warm and real.
-Never sounds like they're selling anything or trying too hard.
-Pacing: Measured, deliberate. Words have weight but don't drag.
-Slight lean into artist and song names, like savoring good wine.
-Keep it tight — short phrases land harder than long ones.
+Style: Comedy roast meets late-night radio. Punchy, confident,
+like you're delivering a punchline to a room full of friends.
+Not angry or mean — just relentlessly funny and a little ruthless.
+Every roast lands with warmth underneath. You're the friend everyone
+wants at the party even though nobody is safe.
+Pacing: Quick setup, punchy delivery. Slight pause before the roast
+lands. Lean into names — both song names and people's names — like
+you're savoring the moment before the joke hits.
 
 TRANSCRIPT:
 %s`


### PR DESCRIPTION
## Summary

- Rewrites the TTS DJ persona from smooth late-night radio to a sharp-witted roast comic who picks a random voice channel listener and roasts them between songs
- Adds `getVoiceChannelMemberNames()` helper that reads Discord's cached guild voice states, filters to the bot's channel, skips the bot itself, and resolves display names (nick > global name > username with DB fallback)
- Passes listener names into every DJ script prompt (transitions, intros, radio start, queue empty) so the LLM can target someone specific
- Provider-agnostic: roast text is generated before TTS synthesis, works identically with both Gemini and Grok

## Test plan

- [ ] Join voice channel with 2+ people, play songs, verify transition announcements roast a listener by name
- [ ] Test with only the bot in voice (no listeners) to confirm it degrades to a normal announcement
- [ ] Test across both Gemini and Grok TTS providers
- [ ] Verify `go build`, `go vet`, `go test ./...` all pass (confirmed locally)