### PR TITLE
fix(player): prevent stale ticker from overwriting NowPlaying card on song transition

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -3057,6 +3057,13 @@ func (p *GuildPlayer) updateNowPlayingCard(queueItem *GuildQueueItem) error {
 		return nil
 	}
 
+	// Guard against stale ticker goroutines writing to the wrong song's card.
+	// The goroutine may have been blocked on the mutex during a song transition;
+	// by the time it unblocks, nowPlayingCurrentItem has already changed.
+	if p.nowPlayingCurrentItem != queueItem {
+		return nil
+	}
+
 	// Get current position from player
 	currentPosition := p.Player.GetPosition()
 


### PR DESCRIPTION
## Why
The NowPlaying embed would flash between the previous song's info and the current song's info during transitions. A ticker goroutine for song n-1 could be blocked waiting on `nowPlayingMutex` when the transition happened; by the time it unblocked, `sendNowPlayingCard` had already posted song n's card, and the stale goroutine would overwrite it with n-1's progress data.

## What Changed
Added a `nowPlayingCurrentItem != queueItem` guard to `updateNowPlayingCard`, matching the identical guard already present in `generateAndUpdateCommentary`. Stale ticker goroutines now exit cleanly when they detect the active item has changed.