### PR TITLE
fix(announce): re-enable TTS when setting voice while disabled

### DIFF
--- a/controller/accessors.go
+++ b/controller/accessors.go
@@ -107,6 +107,14 @@ func (p *GuildPlayer) SetAnnounceVoice(voice string) {
 	p.announceMu.Unlock()
 }
 
+// TriggerTTSRegen signals the TTS watcher to attempt generation for the current transition.
+// Safe to call when no next song is set — generateTransitionTTS will no-op.
+func (p *GuildPlayer) TriggerTTSRegen() {
+	if p.playbackState != nil {
+		p.playbackState.SignalRegen()
+	}
+}
+
 // --- ShouldJoinVoice ---
 
 // ShouldJoinVoice returns true if the bot needs to join (or move to) the given voice channel.

--- a/handlers/playback.go
+++ b/handlers/playback.go
@@ -421,12 +421,28 @@ func (manager *Manager) handleAnnounce(ctx context.Context, interaction *Interac
 		}
 		player.SetAnnounceVoice(matchedVoice)
 
+		// Setting a voice implicitly re-enables announcements when they were off.
+		wasDisabled := !player.GetAnnounceEnabled()
+		if wasDisabled {
+			player.SetAnnounceEnabled(true)
+			if player.DB != nil {
+				if err := player.DB.SetGuildSetting(guildID, "announce_enabled", "true"); err != nil {
+					log.Errorf("Failed to save announce setting: %v", err)
+				}
+			}
+			player.TriggerTTSRegen()
+		}
+
 		hint := manager.Hints.ShowIfApplicable(guildID)
+		msg := fmt.Sprintf("🎙️ DJ voice set to **%s**", matchedVoice)
+		if wasDisabled {
+			msg += " — announcements enabled"
+		}
 
 		return Response{
 			Type: 4,
 			Data: ResponseData{
-				Content: fmt.Sprintf("🎙️ DJ voice set to **%s**", matchedVoice) + hint,
+				Content: msg + hint,
 			},
 		}
 	}


### PR DESCRIPTION
## Summary
- `/announce voice:X` only set the voice without touching `announce_enabled`, leaving the bot stuck in a disabled state if announcements had been toggled off first
- `handleAnnounce` now checks `wasDisabled` in the voice path: re-enables, persists `"true"` to DB, and fires `TriggerTTSRegen` so the queued next song gets TTS immediately
- Added `GuildPlayer.TriggerTTSRegen()` as a thin exported wrapper around `playbackState.SignalRegen()`

## Test Plan
- [ ] `/announce` to disable → confirm bot responds "disabled"
- [ ] `/announce voice:Puck` → confirm response says "DJ voice set to Puck — announcements enabled"
- [ ] Verify TTS fires at the next song transition without needing to queue a new song
- [ ] `/announce voice:Kore` while already enabled → confirm no spurious "announcements enabled" suffix
- [ ] `go test ./...` passes