### PR TITLE
fix(player): clean error messages and fix dead queue item on stream failure

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -499,7 +499,15 @@ func (p *GuildPlayer) loadNext() {
 		log.Tracef("loading next song: %s", next.Video.Title)
 
 		if !next.WaitForStreamURL() {
-			log.Warnf("stream URL not found for %s", next.Video.Title)
+			select {
+			case <-next.streamReady:
+				// handleAdd explicitly closed streamReady (already returned) — safe to remove
+				log.Warnf("stream URL not available for %s, removing from queue", next.Video.Title)
+				p.removeItemByVideoID(next.Video.VideoID)
+			default:
+				// True 30s timeout — handleAdd still running, leave item in place
+				log.Warnf("stream URL timed out for %s, skipping preload", next.Video.Title)
+			}
 			return
 		}
 
@@ -540,7 +548,16 @@ func (p *GuildPlayer) playNext() {
 			})
 
 			if !next.WaitForStreamURL() {
-				log.Warnf("stream URL not available for %s, skipping", next.Video.Title)
+				select {
+				case <-next.streamReady:
+					// handleAdd explicitly closed streamReady (already returned) — safe to remove and advance
+					log.Warnf("stream URL not available for %s, skipping", next.Video.Title)
+					p.removeItemByVideoID(next.Video.VideoID)
+					p.playNext()
+				default:
+					// True 30s timeout — handleAdd still running, leave item in place
+					log.Warnf("stream URL timed out for %s", next.Video.Title)
+				}
 				return
 			}
 		}
@@ -650,6 +667,9 @@ func (p *GuildPlayer) handleAdd(event QueueEvent) {
 				Content: msg,
 				Flags:   64,
 			})
+			if event.Item.streamReady != nil {
+				close(event.Item.streamReady)
+			}
 			return
 		}
 
@@ -659,9 +679,12 @@ func (p *GuildPlayer) handleAdd(event QueueEvent) {
 			Token:   event.Item.Interaction.InteractionToken,
 			AppID:   event.Item.Interaction.AppID,
 			UserID:  event.Item.Interaction.UserID,
-			Content: "Error getting video stream: " + err.Error(),
+			Content: fmt.Sprintf("❌ Can't play **%s**: %s", event.Item.Video.Title, err.Error()),
 			Flags:   64,
 		})
+		if event.Item.streamReady != nil {
+			close(event.Item.streamReady)
+		}
 		return
 	}
 streamReady:
@@ -685,6 +708,9 @@ streamReady:
 	// if the player is stopped, or not loading anything, play the next song in the queue
 	if shouldPlay {
 		next := p.GetNext()
+		if next == nil {
+			return
+		}
 		log.Tracef("no song playing, starting load job for: %s", next.Video.Title)
 		nextCtx := next.Context
 		if nextCtx == nil {

--- a/youtube/client.go
+++ b/youtube/client.go
@@ -504,7 +504,7 @@ func GetVideoStream(ctx context.Context, videoResponse VideoResponse) (*YoutubeS
 					return nil, ErrAgeRestricted
 				}
 				sentry.CaptureException(fmt.Errorf("yt-dlp error after 3 attempts: %v, output: %s", err, string(output)))
-				return nil, fmt.Errorf("yt-dlp error after 3 attempts: %v, output: %s", err, string(output))
+				return nil, fmt.Errorf("%s", extractYtDlpReason(string(output)))
 			}
 			continue
 		}
@@ -519,6 +519,37 @@ func GetVideoStream(ctx context.Context, videoResponse VideoResponse) (*YoutubeS
 		Title:     videoResponse.Title,
 		VideoID:   videoResponse.VideoID,
 	}, nil
+}
+
+// extractYtDlpReason parses yt-dlp combined output for a user-readable error reason.
+// For extractor errors ("ERROR: [youtube] VIDEO_ID: reason"), strips the prefix and
+// video ID to return just the human reason. For other errors, returns the message as-is.
+// Falls back to "video unavailable" if no ERROR line is found.
+func extractYtDlpReason(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "ERROR: ") {
+			continue
+		}
+		rest := strings.TrimPrefix(line, "ERROR: ")
+		if strings.HasPrefix(rest, "[") {
+			// Format: "[extractor] VIDEO_ID: reason" — strip both prefixes
+			if idx := strings.Index(rest, "] "); idx != -1 {
+				afterBracket := rest[idx+2:]
+				parts := strings.SplitN(afterBracket, ": ", 2)
+				if len(parts) == 2 && parts[1] != "" {
+					return parts[1]
+				}
+			}
+			// Bracket format didn't parse cleanly — skip rather than returning a raw video ID
+			continue
+		}
+		// Non-extractor error — return as-is
+		if rest != "" {
+			return rest
+		}
+	}
+	return "video unavailable"
 }
 
 func parseYoutubeDuration(iso string) time.Duration {


### PR DESCRIPTION
## Why
When a video can't be streamed, users saw raw yt-dlp internals (`yt-dlp error after 3 attempts: exit status 1, output: ERROR: [youtube] ID: This video is not available`). The failed item also stayed silently stuck in the queue — the player would wait 30 seconds before logging a warning and returning, leaving the queue blocked until the user manually skipped.

## What Changed
`extractYtDlpReason` parses yt-dlp output to surface just the human reason; Sentry still gets the full dump. Discord messages now show `❌ Can't play **Title**: This video is not available`. `handleAdd` closes `streamReady` on failure so `WaitForStreamURL` returns immediately instead of timing out; `playNext`/`loadNext` distinguish an explicit failure (channel already closed) from a true timeout via a non-blocking channel read, remove the dead item, and advance — without touching items whose `handleAdd` is still in flight. Also adds a nil guard in `handleAdd`'s success block for the pre-existing panic risk when `GetNext` returns nil after a concurrent clear.